### PR TITLE
fix: Col의 offset props에 0을 넣으면 적용되도록 수정한다

### DIFF
--- a/docs/components/Layout.mdx
+++ b/docs/components/Layout.mdx
@@ -148,8 +148,10 @@ mobile first로 설계되어 sm만 설정 되어 있을 경우 sm에서의 설�
 <Playground>
   <Grid>
     <Row>
-      <Col sm={8} smOffset={2}>
+      <Col sm={8} smOffset={2} lgOffset={0}>
         sm-8, sm-offset-2
+        <br />
+        sm-8, lg-offset-0
       </Col>
     </Row>
     <Row>

--- a/src/Col/index.tsx
+++ b/src/Col/index.tsx
@@ -1,9 +1,30 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import { media } from '../BreakPoints';
 import { HTMLDivProps } from '../interfaces/props';
 
-const sizeToPercent = (size?: number) => ((size || 12) / 12) * 100;
+const sizeToPercent = (size?: number) => ((size !== undefined ? size : 12) / 12) * 100;
+const getValidOffset = (offsets: (number | undefined)[]) => {
+  for (const offset of offsets) {
+    if (offset !== undefined) {
+      return offset;
+    }
+  }
+};
+
+const marginLeftStyle = (offsets: (number | undefined)[]) => {
+  const offset = getValidOffset(offsets);
+  if (offset === undefined) {
+    return '';
+  }
+  return css<{
+    smOffset?: number;
+    mdOffset?: number;
+    lgOffset?: number;
+  }>`
+    margin-left: ${sizeToPercent(offset)}%;
+  `;
+};
 
 interface ColProps extends HTMLDivProps {
   sm?: number;
@@ -24,29 +45,17 @@ const Col = styled.div<ColProps>`
     width: ${props => sizeToPercent(props.sm)}%;
     padding-right: 4px;
     padding-left: 4px;
-    ${props =>
-      props.smOffset &&
-      `
-        margin-left: ${sizeToPercent(props.smOffset)}%;
-      `}
+    ${props => marginLeftStyle([props.smOffset])}
   `}
 
   ${media.md`
     width: ${props => sizeToPercent(props.md || props.sm)}%;
-    ${props =>
-      (props.mdOffset || props.smOffset) &&
-      `
-        margin-left: ${sizeToPercent(props.mdOffset || props.smOffset)}%;
-      `}
+    ${props => marginLeftStyle([props.mdOffset, props.smOffset])};
   `}
 
   ${media.lg`
     width: ${props => sizeToPercent(props.lg || props.md || props.sm)}%;
-    ${props =>
-      (props.lgOffset || props.mdOffset || props.smOffset) &&
-      `
-        margin-left: ${sizeToPercent(props.lgOffset || props.mdOffset || props.smOffset)}%;
-      `}
+    ${props => marginLeftStyle([props.lgOffset, props.mdOffset, props.smOffset])};
   `};
 `;
 


### PR DESCRIPTION
0이 falsy인 것 때문에 smOffset을 데스크탑에서 리셋하려고 lgOffset 0을 넣으면 적용되지 않았음
getValidOffset을 추가해서 undefined 아닌 offset 우선 값을 구한다