### PR TITLE
fix: Anchor button disabeld

### DIFF
--- a/docs/components/Button.mdx
+++ b/docs/components/Button.mdx
@@ -92,7 +92,7 @@ import { Icon, Colors, Button } from '@class101/ui';
   <Button href="/" target="_blank">
     Native A Tag
   </Button>
-  <Button to="/" target="_blank">
+  <Button to="/" target="_blank" disabled>
     Link of React Router Dom
   </Button>
 </Playground>

--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -298,18 +298,24 @@ const buttonStyle = css<StyledContainerProps>`
     vertical-align: middle;
   }
 
-  &:hover {
+  &:hover,
+  &[hover] {
     opacity: 0.9;
     text-decoration: none;
   }
 
-  &:disabled {
+  &:disabled,
+  &[disabled] {
     cursor: not-allowed;
     color: ${gray200};
     background-color: ${gray000};
     path {
       fill: ${gray200};
     }
+  }
+
+  &[disabled] {
+    pointer-events: none;
   }
 `;
 


### PR DESCRIPTION
- 앵커버튼의 disabled가 안먹는 문제를 수정합니다
- react-router에서 disabled를 지원하지 않아 pointer-events:none을
추가합니다
- 해당 css는 IE에서 지원하지 않습니다.