### PR TITLE
 feat: 외부에서 캐러셀을 조작할 수 있는 속성을 추가한다

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p><a href="https://class101-ui.netlify.com" target="_blank" rel="noopener noreferrer"><img width="128" src="https://s3.ap-northeast-2.amazonaws.com/class101-ui/images/logo-class101.png" alt="C"></a></p>
 
 <p>
-  <a href="https://www.npmjs.com/package/class101-ui">
+  <a href="https://www.npmjs.com/package/@class101/ui">
     <img
-      src="https://img.shields.io/npm/v/class101-ui.svg"
+      src="https://img.shields.io/npm/v/@class101/ui.svg"
       alt="npm"
     >
   </a>

--- a/docs/components/Carousel.mdx
+++ b/docs/components/Carousel.mdx
@@ -298,3 +298,36 @@ slidesPerView 값이 1일 경우 기본적으로 spaceBetween 값은 0입니다.
   }}
 
 </Playground>
+
+loop 모드
+
+<Playground>
+  {() => {
+    class Example extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = { 
+          currentIndex: 0, 
+        };
+      }
+      render() {
+        return (
+          <div>
+            <Carousel onChangeSlides={(index) => this.setState({ currentIndex: index })} activeSlideIndex={this.state.currentIndex} loop>
+              <PlayGroundBanner backgroundColor={Colors.red100}>배너1</PlayGroundBanner>
+              <PlayGroundBanner backgroundColor={Colors.red200}>배너2</PlayGroundBanner>
+              <PlayGroundBanner backgroundColor={Colors.red300}>배너3</PlayGroundBanner>
+            </Carousel>
+            <div>
+              <button onClick={() => this.setState({ currentIndex: 0 })}>1 {this.state.currentIndex === 0 && 'active!!'}</button>
+              <button onClick={() => this.setState({ currentIndex: 1 })}>2 {this.state.currentIndex === 1 && 'active!!'}</button>
+              <button onClick={() => this.setState({ currentIndex: 2 })}>3 {this.state.currentIndex === 2 && 'active!!'}</button>
+            </div>
+          </div>
+        )
+      }
+    }
+    return <Example/>;
+  }}
+
+</Playground>

--- a/docs/components/Carousel.mdx
+++ b/docs/components/Carousel.mdx
@@ -220,7 +220,13 @@ slidesPerView 값이 1일 경우 기본적으로 spaceBetween 값은 0입니다.
 ## Lazy
 
 <Playground>
-  <Carousel navigationPosition={CarouselNavigationPosition.TopRightOut} lgSlidesPerView={4} lazy pagination>
+  <Carousel
+    navigationPosition={CarouselNavigationPosition.TopRightOut}
+    lgSlidesPerView={4}
+    smSlidesPerView={2}
+    lazy
+    pagination
+  >
     <SwiperCard>
       <img data-src={imageSrc} className="swiper-lazy" />
       <PreloadImage className="swiper-lazy-preloader" />
@@ -258,4 +264,37 @@ slidesPerView 값이 1일 경우 기본적으로 spaceBetween 값은 0입니다.
       <PreloadImage className="swiper-lazy-preloader" />
     </SwiperCard>
   </Carousel>
+</Playground>
+
+## External operation
+
+`onChangeSlides`과 `activeSlideIndex`로 외부에서 캐러셀을 조작할 수 있습니다.
+
+<Playground>
+  {() => {
+    class Example extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = { currentIndex: 0 };
+      }
+      render() {
+        return (
+          <div>
+            <Carousel onChangeSlides={(index) => this.setState({ currentIndex: index})} activeSlideIndex={this.state.currentIndex}>
+              <PlayGroundBanner backgroundColor={Colors.red100}>배너1</PlayGroundBanner>
+              <PlayGroundBanner backgroundColor={Colors.red200}>배너2</PlayGroundBanner>
+              <PlayGroundBanner backgroundColor={Colors.red300}>배너3</PlayGroundBanner>
+            </Carousel>
+            <div>
+              <button onClick={() => this.setState({ currentIndex: 0 })}>1 {this.state.currentIndex === 0 && 'active!!'}</button>
+              <button onClick={() => this.setState({ currentIndex: 1 })}>2 {this.state.currentIndex === 1 && 'active!!'}</button>
+              <button onClick={() => this.setState({ currentIndex: 2 })}>3 {this.state.currentIndex === 2 && 'active!!'}</button>
+            </div>
+          </div>
+        )
+      }
+    }
+    return <Example/>;
+  }}
+
 </Playground>

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-dom": "^16.8.0",
     "react-router-dom": "^4.3.1",
     "styled-components": "4.2.0",
-    "react-id-swiper": "2.1.2",
+    "react-id-swiper": "2.3.1",
     "swiper": "4.5.0"
   },
   "devDependencies": {
@@ -96,7 +96,7 @@
     "styled-components": "4.2.0",
     "tslib": "^1.9.3",
     "tslint": "^5.12.0",
-    "react-id-swiper": "2.1.2",
+    "react-id-swiper": "2.3.1",
     "swiper": "4.5.0"
   },
   "files": [

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -83,7 +83,12 @@ export default class Carousel extends PureComponent<CarouselProps, State> {
 
   public componentDidUpdate(prevProps: CarouselProps) {
     const { activeSlideIndex } = this.props;
-    if (activeSlideIndex !== undefined && activeSlideIndex !== prevProps.activeSlideIndex) {
+    if (
+      activeSlideIndex !== undefined &&
+      activeSlideIndex !== prevProps.activeSlideIndex &&
+      this.swiper &&
+      activeSlideIndex !== this.swiper.realIndex
+    ) {
       this.goToSlides(activeSlideIndex);
     }
   }
@@ -155,6 +160,9 @@ export default class Carousel extends PureComponent<CarouselProps, State> {
 
   private goToSlides = (index: number) => {
     if (this.swiper) {
+      if (this.props.loop) {
+        return this.swiper.slideToLoop(index);
+      }
       this.swiper.slideTo(index);
     }
   };
@@ -162,7 +170,7 @@ export default class Carousel extends PureComponent<CarouselProps, State> {
   private onChange = () => {
     const { onChangeSlides } = this.props;
     if (this.swiper && onChangeSlides) {
-      onChangeSlides(this.swiper.activeIndex);
+      onChangeSlides(this.swiper.realIndex);
     }
   };
 

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -36,6 +36,8 @@ export interface CarouselProps {
   shouldSwiperUpdate: boolean;
   className?: string;
   children: React.ReactNode;
+  onChangeSlides?: (index: number) => void;
+  activeSlideIndex?: number;
 }
 
 const DEFAULT_PARAMS = {
@@ -71,12 +73,20 @@ export default class Carousel extends PureComponent<CarouselProps, State> {
     freeMode: true,
     loop: false,
   };
+
   public readonly state = {
     isBeginning: true,
     isEnd: false,
   };
 
   private swiper: SwiperInstance = null;
+
+  public componentDidUpdate(prevProps: CarouselProps) {
+    const { activeSlideIndex } = this.props;
+    if (activeSlideIndex !== undefined && activeSlideIndex !== prevProps.activeSlideIndex) {
+      this.goToSlides(activeSlideIndex);
+    }
+  }
 
   public render() {
     const {
@@ -143,6 +153,19 @@ export default class Carousel extends PureComponent<CarouselProps, State> {
     }
   };
 
+  private goToSlides = (index: number) => {
+    if (this.swiper) {
+      this.swiper.slideTo(index);
+    }
+  };
+
+  private onChange = () => {
+    const { onChangeSlides } = this.props;
+    if (this.swiper && onChangeSlides) {
+      onChangeSlides(this.swiper.activeIndex);
+    }
+  };
+
   private progress = () => {
     if (!this.swiper) return;
     if (this.props.loop) {
@@ -185,6 +208,7 @@ export default class Carousel extends PureComponent<CarouselProps, State> {
       on: {
         ...on,
         progress: this.progress,
+        slideChange: this.onChange,
       },
       slidesPerView: lgSlidesPerView,
       spaceBetween: lgSpaceBetween || (typeof lgSlidesPerView !== 'number' || lgSlidesPerView !== 1) ? 24 : 0,

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -1,10 +1,9 @@
-import { isEqual } from 'lodash-es';
 import React, { PureComponent } from 'react';
-import Swiper, { ReactIdSwiperProps, SwiperInstance } from 'react-id-swiper';
-import { SwiperModules } from 'react-id-swiper/lib/types';
+import ReactIdSwiper from 'react-id-swiper/lib/ReactIdSwiper.custom';
+import { ReactIdSwiperCustomProps, SwiperInstance, SwiperModules } from 'react-id-swiper/lib/types';
 import styled, { css, FlattenSimpleInterpolation } from 'styled-components';
 import { AutoplayOptions, PaginationOptions, SwiperEvent } from 'swiper';
-import { Autoplay, Lazy, LazyOptions, Pagination } from 'swiper/dist/js/swiper.esm';
+import { Autoplay, Lazy, LazyOptions, Pagination, Swiper } from 'swiper/dist/js/swiper.esm';
 
 import { media, SIZES } from '../../BreakPoints';
 import { gray700, white } from '../../Colors';
@@ -40,7 +39,9 @@ export interface CarouselProps {
 }
 
 const DEFAULT_PARAMS = {
+  Swiper,
   threshold: 10,
+  modules: [],
 };
 
 const DEFAULT_PAGINATION_PARAMS: { [key in string]: PaginationOptions } = {
@@ -77,12 +78,6 @@ export default class Carousel extends PureComponent<CarouselProps, State> {
 
   private swiper: SwiperInstance = null;
 
-  public componentDidUpdate(prevProps: Readonly<CarouselProps>) {
-    if (this.props.shouldSwiperUpdate && this.shouldSwiperUpdate(prevProps) && this.swiper) {
-      this.swiper.update();
-    }
-  }
-
   public render() {
     const {
       children,
@@ -112,9 +107,9 @@ export default class Carousel extends PureComponent<CarouselProps, State> {
               lgSlidesSideOffset={lgSlidesSideOffset}
               smSlidesSideOffset={smSlidesSideOffset}
             >
-              <Swiper {...swiperParams} getSwiper={this.getSwiper}>
+              <ReactIdSwiper {...swiperParams} getSwiper={this.getSwiper}>
                 {children}
-              </Swiper>
+              </ReactIdSwiper>
             </SwiperWrapper>
           )}
           {navigation && !shouldHideNavigation && (
@@ -131,25 +126,6 @@ export default class Carousel extends PureComponent<CarouselProps, State> {
       </Container>
     );
   }
-
-  private shouldSwiperUpdate = (prevProps: Readonly<CarouselProps>) => {
-    const prevKeys = this.getKeysFromChildren(prevProps.children);
-    const currentKeys = this.getKeysFromChildren(this.props.children);
-    return !isEqual(prevKeys, currentKeys);
-  };
-
-  private getKeysFromChildren = (children?: React.ReactNode) => {
-    if (children === undefined || children === null) {
-      return [];
-    }
-
-    return React.Children.map(children, child => {
-      if (!React.isValidElement(child)) {
-        return undefined;
-      }
-      return child.key;
-    });
-  };
 
   private getSwiper = (swiper: SwiperInstance) => {
     this.swiper = swiper;
@@ -187,7 +163,7 @@ export default class Carousel extends PureComponent<CarouselProps, State> {
     });
   };
 
-  private getSwiperParams = (): Partial<ReactIdSwiperProps> => {
+  private getSwiperParams = (): ReactIdSwiperCustomProps => {
     const {
       pagination,
       lgSlidesPerView,
@@ -201,7 +177,7 @@ export default class Carousel extends PureComponent<CarouselProps, State> {
       freeMode,
       shouldSwiperUpdate,
     } = this.props;
-    let params: Partial<ReactIdSwiperProps> = {
+    let params: ReactIdSwiperCustomProps = {
       ...DEFAULT_PARAMS,
       shouldSwiperUpdate,
       loop,
@@ -218,7 +194,6 @@ export default class Carousel extends PureComponent<CarouselProps, State> {
           spaceBetween: smSpaceBetween || (typeof smSlidesPerView !== 'number' || smSlidesPerView !== 1) ? 16 : 0,
         },
       },
-      modules: [],
     };
     if (autoplay) {
       params = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12621,10 +12621,10 @@ react-hot-loader@^4.6.0, react-hot-loader@^4.6.3:
     shallowequal "^1.0.2"
     source-map "^0.7.3"
 
-react-id-swiper@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/react-id-swiper/-/react-id-swiper-2.1.2.tgz#57dfb0e8b8703dfe544ea5af94b74663822a2b63"
-  integrity sha512-7VLfDUNsY3Mb3lYtltiuyWHb/BMF8YH8+JotpHNuoORFqaj2FER82xHPQdb90HyJ+I3+wL1443suyE2KdAC6aw==
+react-id-swiper@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-id-swiper/-/react-id-swiper-2.3.1.tgz#a5718c717f722868a2d18cf39a3db87878e48af3"
+  integrity sha512-ftdKp6l6WImE7RRPMlfByogB3fz+8c0zVla92MpPpcuewcO3znNCBcPEqaU6PIT2fDf3RWqwOFEbj6wxdey3MQ==
   dependencies:
     object-assign "^4.1.1"
 
@@ -14819,7 +14819,7 @@ swap-case@^1.1.0:
     lower-case "^1.1.1"
     upper-case "^1.1.1"
 
-swiper@^4.5.0:
+swiper@4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/swiper/-/swiper-4.5.0.tgz#4d870bec4f5abe2fb259325849dd2641c9243c0d"
   integrity sha512-jRCd/CGet9kaHwthHdd/sL/YU8CI157PWLyItnIcn/o/jP4haVky3zTF6f9F3JDpmQIw7jdWihISiYx0/oTHsg==


### PR DESCRIPTION
react-id-swiper 2.3.1에서 기존 update 관련된 버그가 픽스되어 보완했던 코드를 제거했습니다
외부에서 캐러셀을 조작할 수 있는 onChangeSlides, activeSlideIndex를 추가했습니다.