### PR TITLE
fix: carousel ViewAllButton의 타입에러를 수정한다

### DIFF
--- a/docs/components/Button.mdx
+++ b/docs/components/Button.mdx
@@ -253,5 +253,11 @@ export enum ButtonSize {
     <Button size="xs" variant="default" theme={Theme.dark} leftIcon={<Icon.Heart />}>
       Click me
     </Button>
+    <div style={{ display: 'flex' }}>
+      <Button>Click me</Button>
+      <Button fill color={ButtonColor.ORANGE}>
+        Click me
+      </Button>
+    </div>
   </PlayGroundContainer>
 </Playground>

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@babel/preset-react": "^7.0.0",
     "@emotion/core": "^10.0.6",
     "@pedaling/tslint-config-class101": "^1.0.3",
+    "@types/classnames": "^2.2.9",
     "@types/jest": "^23.3.12",
     "@types/lodash": "^4.14.136",
     "@types/react": "^16.7.18",
@@ -104,6 +105,7 @@
     "dist"
   ],
   "dependencies": {
+    "classnames": "^2.2.6",
     "path-to-regexp": "^3.0.0",
     "polished": "^3.4.1",
     "typescript": "3.1.6"

--- a/src/components/Button/TextButton/index.tsx
+++ b/src/components/Button/TextButton/index.tsx
@@ -26,7 +26,6 @@ interface CommonProps {
   disabled?: boolean;
   target?: string;
   className?: string;
-  icon?: boolean;
 }
 
 type OmittedAnchorAttributes = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof CommonProps>;
@@ -124,7 +123,6 @@ export default class TextButton extends PureComponent<Props> {
           color={color}
           theme={theme}
           className={classNames(className, { disabled })}
-          disabled={disabled}
           {...anchorAttributes}
           {...restProps}
           {...options}
@@ -142,7 +140,6 @@ export default class TextButton extends PureComponent<Props> {
           color={color}
           theme={theme}
           className={classNames(className, { disabled })}
-          disabled={disabled}
           {...anchorAttributes}
           {...restProps}
           {...options}

--- a/src/components/Button/TextButton/index.tsx
+++ b/src/components/Button/TextButton/index.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { darken } from 'polished';
 import React, { AnchorHTMLAttributes, ButtonHTMLAttributes, PureComponent, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
@@ -62,6 +63,7 @@ export default class TextButton extends PureComponent<Props> {
       anchorAttributes,
       buttonAttributes,
       color,
+      className,
       ...restProps
     } = this.props;
     if (loading) {
@@ -121,7 +123,7 @@ export default class TextButton extends PureComponent<Props> {
           size={size}
           color={color}
           theme={theme}
-          data-ui-disabled={disabled}
+          className={classNames(className, { disabled })}
           disabled={disabled}
           {...anchorAttributes}
           {...restProps}
@@ -139,7 +141,7 @@ export default class TextButton extends PureComponent<Props> {
           size={size}
           color={color}
           theme={theme}
-          data-ui-disabled={disabled}
+          className={classNames(className, { disabled })}
           disabled={disabled}
           {...anchorAttributes}
           {...restProps}
@@ -156,7 +158,7 @@ export default class TextButton extends PureComponent<Props> {
         size={size}
         color={color}
         theme={theme}
-        data-ui-disabled={disabled}
+        className={classNames(className, { disabled })}
         disabled={disabled}
         {...buttonAttributes}
         {...restProps}
@@ -216,13 +218,12 @@ const buttonCommonStyle = css<CommonProps>`
     }
   }
 
-  &[data-ui-disabled] {
+  &.disabled {
     color: ${props => getTextButtonColors(props.color, props.theme.mode).disabledTextColor};
   }
 
-  &:disabled,
-  &[disabled],
-  &[data-ui-disabled] {
+  &.disabled,
+  &:disabled {
     pointer-events: none;
     cursor: not-allowed;
   }

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { darken } from 'polished';
 import React, { AnchorHTMLAttributes, ButtonHTMLAttributes, PureComponent, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
@@ -65,6 +66,7 @@ export default class ContainButton extends PureComponent<Props> {
       anchorAttributes,
       buttonAttributes,
       color,
+      className,
       ...restProps
     } = this.props;
     if (loading) {
@@ -125,7 +127,7 @@ export default class ContainButton extends PureComponent<Props> {
           size={size}
           color={color}
           theme={theme}
-          data-ui-disabled={disabled}
+          className={classNames(className, { disabled })}
           disabled={disabled}
           fill={`${fill}`}
           {...anchorAttributes}
@@ -144,7 +146,7 @@ export default class ContainButton extends PureComponent<Props> {
           size={size}
           color={color}
           theme={theme}
-          data-ui-disabled={disabled}
+          className={classNames(className, { disabled })}
           disabled={disabled}
           fill={`${fill}`}
           {...anchorAttributes}
@@ -162,7 +164,7 @@ export default class ContainButton extends PureComponent<Props> {
         size={size}
         color={color}
         theme={theme}
-        data-ui-disabled={disabled}
+        className={classNames(className, { disabled })}
         disabled={disabled}
         fill={`${fill}`}
         {...buttonAttributes}
@@ -247,14 +249,13 @@ const buttonCommonStyle = css<StyledContainerProps>`
     text-decoration-line: none;
   }
 
-  &[data-ui-disabled='true'] {
+  &.disabled {
     color: ${props => getButtonColors(props.color, props.theme.mode).disabledTextColor};
     background-color: ${props => getButtonColors(props.color, props.theme.mode).disabledBackgroundColor};
   }
 
   &:disabled,
-  &[disabled],
-  &[data-ui-disabled='true'] {
+  &.disabled {
     pointer-events: none;
     cursor: not-allowed;
   }

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -26,7 +26,6 @@ interface CommonProps {
   disabled?: boolean;
   target?: string;
   className?: string;
-  icon?: boolean;
 }
 
 type OmittedAnchorAttributes = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof CommonProps>;
@@ -128,7 +127,6 @@ export default class ContainButton extends PureComponent<Props> {
           color={color}
           theme={theme}
           className={classNames(className, { disabled })}
-          disabled={disabled}
           fill={`${fill}`}
           {...anchorAttributes}
           {...restProps}
@@ -147,7 +145,6 @@ export default class ContainButton extends PureComponent<Props> {
           color={color}
           theme={theme}
           className={classNames(className, { disabled })}
-          disabled={disabled}
           fill={`${fill}`}
           {...anchorAttributes}
           {...restProps}

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -180,6 +180,7 @@ interface StyledContainerProps extends CommonProps {
 
 const buttonTextStyleBySize: { [key in ButtonSize]: FlattenSimpleInterpolation } = {
   [ButtonSize.LARGE]: css`
+    font-weight: bold;
     font-size: 16px;
     letter-spacing: -0.2px;
   `,
@@ -216,7 +217,7 @@ const buttonStyleBySize: { [key in ButtonSize]: FlattenSimpleInterpolation } = {
 };
 
 const buttonCommonStyle = css<StyledContainerProps>`
-  flex: none;
+  flex: initial;
   outline: none;
   border: none;
   cursor: pointer;
@@ -246,14 +247,14 @@ const buttonCommonStyle = css<StyledContainerProps>`
     text-decoration-line: none;
   }
 
-  &[data-ui-disabled] {
+  &[data-ui-disabled='true'] {
     color: ${props => getButtonColors(props.color, props.theme.mode).disabledTextColor};
     background-color: ${props => getButtonColors(props.color, props.theme.mode).disabledBackgroundColor};
   }
 
   &:disabled,
   &[disabled],
-  &[data-ui-disabled] {
+  &[data-ui-disabled='true'] {
     pointer-events: none;
     cursor: not-allowed;
   }
@@ -264,6 +265,7 @@ const ButtonContainer = styled.button<StyledContainerProps>`
 `;
 
 const Text = styled.div`
+  flex: none;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/Carousel/ViewAllButton/index.tsx
+++ b/src/components/Carousel/ViewAllButton/index.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { orange50, orange600 } from '../../../Colors';
+import { orange600 } from '../../../Colors';
 import { Add } from '../../../Icon';
-import { body2 } from '../../../TextStyles';
 import Button, { ButtonProps } from '../../Button';
+import { ButtonColor } from '../../Button/interface';
 
-export default class ViewAllButton extends React.PureComponent<ButtonProps> {
+export default class ViewAllButton extends React.PureComponent<Partial<ButtonProps>> {
   public render() {
     return (
-      <AllButton {...this.props}>
+      <AllButton color={ButtonColor.ORANGE_LIGHT} {...this.props}>
         <Inner>
           <Add size={18} fillColor={orange600} />
           <Text>전체보기</Text>
@@ -29,11 +29,6 @@ const AllButton = styled(Button)`
   min-height: 42px;
   height: auto;
   padding: 0;
-  background: none;
-  &:hover,
-  &:focus {
-    background-color: ${orange50};
-  }
 `;
 
 const Inner = styled.div`
@@ -44,7 +39,5 @@ const Inner = styled.div`
 `;
 
 const Text = styled.div`
-  ${body2};
-  color: ${orange600};
   margin-top: 4px;
 `;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,6 +10,6 @@ export { default as Navigation } from './Navigation';
 export * from './FilterList';
 export * from './RadioButtonGroup';
 export * from './Button/interface';
-export { default as Button } from './Button';
-export { default as TextButton } from './Button/TextButton';
+export { default as Button, ButtonProps } from './Button';
+export { default as TextButton, TextButtonProps } from './Button/TextButton';
 export * from './ButtonGroup';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1379,6 +1379,11 @@
     "@svgr/plugin-svgo" "^4.0.3"
     loader-utils "^1.1.0"
 
+"@types/classnames@^2.2.9":
+  version "2.2.9"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.9.tgz#d868b6febb02666330410fe7f58f3c4b8258be7b"
+  integrity sha512-MNl+rT5UmZeilaPxAVs6YaPC2m6aA8rofviZbhbxpPpl61uKodfdQVsBtgJGTqGizEf02oW3tsVe7FYB8kK14A==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"


### PR DESCRIPTION
- Type error: Type '{ to: string; }' is not assignable to type 'Readonly<Props>'
- Property 'color' is missing in type '{ to: string; }'