### PR TITLE
fix: 캐러셀 버튼이 disabled일 때 뒤의 요소가 클릭되지 않도록 한다

### DIFF
--- a/docs/components/Carousel.mdx
+++ b/docs/components/Carousel.mdx
@@ -108,9 +108,15 @@ enum CarouselPaginationTheme {
     paginationTheme={CarouselPaginationTheme.Dark}
     pagination
   >
-    <PlayGroundBanner backgroundColor={Colors.red100}>배너1</PlayGroundBanner>
-    <PlayGroundBanner backgroundColor={Colors.red200}>배너2</PlayGroundBanner>
-    <PlayGroundBanner backgroundColor={Colors.red300}>배너3</PlayGroundBanner>
+    <PlayGroundBanner backgroundColor={Colors.red100} onClick={() => alert('clicked')}>
+      배너1
+    </PlayGroundBanner>
+    <PlayGroundBanner backgroundColor={Colors.red200} onClick={() => alert('clicked')}>
+      배너2
+    </PlayGroundBanner>
+    <PlayGroundBanner backgroundColor={Colors.red300} onClick={() => alert('clicked')}>
+      배너3
+    </PlayGroundBanner>
   </Carousel>
   <Carousel
     navigationPosition={CarouselNavigationPosition.BottomRightIn}

--- a/src/GlobalStyle/swiperDefaultStyle.ts
+++ b/src/GlobalStyle/swiperDefaultStyle.ts
@@ -107,7 +107,7 @@ const swiperStyle = css`
     -ms-touch-action: pan-x;
     touch-action: pan-x;
   }
-  .swiper-button-prev,
+  /* .swiper-button-prev,
   .swiper-button-next {
     position: absolute;
     top: 50%;
@@ -125,7 +125,7 @@ const swiperStyle = css`
     opacity: 0.35;
     cursor: auto;
     pointer-events: none;
-  }
+  } */
   .swiper-button-lock {
     display: none;
   }

--- a/src/components/Button/IconButton/index.tsx
+++ b/src/components/Button/IconButton/index.tsx
@@ -20,7 +20,7 @@ export interface IconButtonProps extends ButtonCommonProps<IconButtonColorValue,
   fillColor?: string;
 }
 
-export default class ContainButton extends PureComponent<IconButtonProps> {
+export default class IconButton extends PureComponent<IconButtonProps> {
   public static defaultProps: Partial<IconButtonProps> = {
     theme: Theme.light,
     size: ButtonSize.SMALL,

--- a/src/components/Carousel/Navigation/NavigationButton/index.tsx
+++ b/src/components/Carousel/Navigation/NavigationButton/index.tsx
@@ -3,6 +3,8 @@ import styled, { css, FlattenSimpleInterpolation } from 'styled-components';
 
 import { elevation1 } from '../../../../ElevationStyles';
 import { Chevron } from '../../../../Icon';
+import IconButton from '../../../Button/IconButton';
+import { ButtonColor } from '../../../Button/interface';
 
 const NAVIGATION_BUTTON_SIZE = 32;
 
@@ -15,15 +17,21 @@ interface Props {
   direction: NavigationDirection;
   onClick: () => void;
   className?: string;
+  disabled: boolean;
 }
 
 export default class NavigationButton extends React.PureComponent<Props> {
   public render() {
-    const { direction, onClick, className } = this.props;
+    const { direction, onClick, className, disabled } = this.props;
     return (
-      <Button onClick={onClick} direction={direction} className={className}>
-        <ChevronIcon direction={direction} size={24} />
-      </Button>
+      <Button
+        color={ButtonColor.WHITE}
+        onClick={onClick}
+        direction={direction}
+        className={className}
+        disabled={disabled}
+        icon={<Chevron />}
+      />
     );
   }
 }
@@ -32,49 +40,23 @@ const navigationDirectionStyle: { [key in NavigationDirection]: FlattenSimpleInt
   [NavigationDirection.Next]: css`
     left: auto;
     right: 0;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
   `,
   [NavigationDirection.Prev]: css`
     left: auto;
     right: ${NAVIGATION_BUTTON_SIZE}px;
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    svg {
+      transform: rotate(180deg);
+    }
   `,
 };
 
-const Button = styled.button<{ direction: NavigationDirection }>`
+const Button = styled(IconButton)<{ direction: NavigationDirection }>`
   ${elevation1};
-  /* Reset swiper's default style */
-  background: none;
-  border: none;
-  margin: 0;
-
-  /* Customize navigation button  */
   position: absolute;
   top: 0;
   ${props => navigationDirectionStyle[props.direction]};
-  width: ${NAVIGATION_BUTTON_SIZE}px;
-  height: ${NAVIGATION_BUTTON_SIZE}px;
-  background-color: white;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  &:focus {
-    outline: none;
-  }
-  &:active {
-    opacity: 0.8;
-  }
-`;
-
-const ChevronIcon = styled(Chevron)<{ direction: NavigationDirection }>`
-  flex: none;
-  ${props =>
-    props.direction === NavigationDirection.Prev
-      ? `
-          transform: rotate(180deg);
-        `
-      : ''};
 `;

--- a/src/components/Carousel/Navigation/index.tsx
+++ b/src/components/Carousel/Navigation/index.tsx
@@ -38,11 +38,13 @@ export default class Navigation extends React.PureComponent<Props> {
         <NavigationButton
           direction={NavigationDirection.Prev}
           onClick={goPrev}
+          disabled={isBeginning}
           className={classNames(NavigationDirection.Prev, isBeginning)}
         />
         <NavigationButton
           direction={NavigationDirection.Next}
           onClick={goNext}
+          disabled={isEnd}
           className={classNames(NavigationDirection.Next, isEnd)}
         />
       </Container>


### PR DESCRIPTION
- opacity와 point-events를 함께 사용하면 뒤의 요소에 접근할 수 있다
