### PR TITLE
fix: Switch onText, offText삭제하고 labelComponent 사용

### DIFF
--- a/docs/formInputs/Switch.mdx
+++ b/docs/formInputs/Switch.mdx
@@ -14,8 +14,6 @@ import { PlayGroundButtonContainer } from '../docsComponents';
 
 <PropsTable of={Switch} />
 
-**`onText`와 `offText`는 함께 설정해야 동작합니다.**
-
 ## Basic usage
 
 ```ts
@@ -31,12 +29,16 @@ import { Switch, Colors } from '@class101/ui';
 
 ## With Text
 
+`labeComponent`와 `children`의 타입은 같습니다.
+
+**Checked 상태에 따라 텍스트가 변하는 것은 UX적으로 추천하지 않습니다.**
+
 <Playground>
   <PlayGroundButtonContainer style={{ width: '250px' }}>
-    <Switch checked>크레딧 사용 여부</Switch>
-    <Switch onText="다크모드 켜짐" offText="다크모드 꺼짐" />
-    <Switch onText="다크모드 켜짐" offText="다크모드 꺼짐" disabled />
-    <Switch onText={<span>with component</span>} offText={<Icon.Bell />} />
+    <Switch checked>크레딧 사용</Switch>
+    <Switch labelComponent="내 위치 공유" />
+    <Switch disabled><span>벨소리 사용</span></Switch>
+    <Switch labelComponent={(checked) => checked ? "checked" : "unchecked"} />
 
   </PlayGroundButtonContainer>
 </Playground>
@@ -72,8 +74,8 @@ import { Switch, Colors } from '@class101/ui';
     <Switch inline />
   </PlayGroundButtonContainer>
   <PlayGroundButtonContainer>
-    <Switch onText="다크모드 켜짐" offText="다크모드 꺼짐" inline checked />
-    <Switch onText="다크모드 켜짐" offText="다크모드 꺼짐" inline />
-    <Switch onText="다크모드 켜짐" offText="다크모드 꺼짐" inline disabled />
+    <Switch labelComponent="다크모드 사용" inline checked />
+    <Switch labelComponent="다크모드 사용" inline />
+    <Switch labelComponent="다크모드 사용" inline disabled />
   </PlayGroundButtonContainer>
 </Playground>

--- a/src/formInputs/Switch/index.tsx
+++ b/src/formInputs/Switch/index.tsx
@@ -6,6 +6,8 @@ import { elevation1 } from '../../core/ElevationStyles';
 import { body2 } from '../../core/TextStyles';
 import { Theme, ThemeConfig } from '../../core/Theme';
 
+export type SwitchLabelType = (checked: boolean) => React.ReactNode | React.ReactNode;
+
 export interface SwitchProps {
   theme: ThemeConfig;
   disabled: boolean;
@@ -14,9 +16,8 @@ export interface SwitchProps {
   hoverColor: string;
   onChange?: (e: ChangeEvent<HTMLInputElement>) => boolean | void;
   inline?: boolean;
-  onText?: React.ReactNode;
-  offText?: React.ReactNode;
-  children?: React.ReactNode;
+  labelComponent?: SwitchLabelType;
+  children?: SwitchLabelType;
 }
 
 export interface SwitchState {
@@ -37,14 +38,14 @@ export class Switch extends PureComponent<SwitchProps, SwitchState> {
   };
 
   public render() {
-    const { inline, onText, offText, children, disabled, color, hoverColor, ...restProps } = this.props;
+    const { inline, labelComponent, children, disabled, color, hoverColor, ...restProps } = this.props;
     const { checked } = this.state;
-    const textExists = children || (onText && offText);
+    const label = children || (typeof labelComponent === 'function' ? labelComponent(checked) : labelComponent);
     return (
       <StyledSwitchContainer inline={inline} disabled={disabled} {...restProps}>
-        {textExists && (
+        {label && (
           <StyledSwitchText inline={inline} disabled={disabled}>
-            {children || (checked ? onText : offText)}
+            {label}
           </StyledSwitchText>
         )}
         <StyledSwitchBase>

--- a/src/formInputs/Switch/index.tsx
+++ b/src/formInputs/Switch/index.tsx
@@ -6,7 +6,7 @@ import { elevation1 } from '../../core/ElevationStyles';
 import { body2 } from '../../core/TextStyles';
 import { Theme, ThemeConfig } from '../../core/Theme';
 
-export type SwitchLabelType = (checked: boolean) => React.ReactNode | React.ReactNode;
+export type SwitchLabelType = ((checked: boolean) => React.ReactNode) | React.ReactNode;
 
 export interface SwitchProps {
   theme: ThemeConfig;


### PR DESCRIPTION
fix #99 

onText와 offText를 삭제하고 labelComponent를 사용했습니다.

## Image
![image](https://user-images.githubusercontent.com/32216112/63922552-dda8df00-ca7f-11e9-8da0-19356b9e584d.png)
