### PR TITLE
fix: ModalBottomSheet 모바일일때 padding bottom 24px로 수정

### DIFF
--- a/src/overlays/ModalBottomSheet/index.tsx
+++ b/src/overlays/ModalBottomSheet/index.tsx
@@ -252,7 +252,6 @@ const StyledBottomSheetDialog = styled.div<{ visible: boolean }>`
     min-height: 240px;
     transition: all 225ms ease-out;
     padding: 24px;
-    padding-bottom: 32px;
   `}
   background: ${white};
   box-sizing: border-box;


### PR DESCRIPTION
디자인 시안이 바뀌어서 모바일일때 padding bottom을 24픽셀로 수정했습니다.

![image](https://user-images.githubusercontent.com/32216112/64013388-a52a0380-cb5a-11e9-9f55-292cf845ea6c.png)
