### PR TITLE
fix: 사파리에서 Switch 컴포넌트에서`cursor: pointer`가 안먹는 오류 수정.

### DIFF
--- a/src/formInputs/Switch/index.tsx
+++ b/src/formInputs/Switch/index.tsx
@@ -107,13 +107,13 @@ const StyledSwitchInput = styled.input<{ disabled: boolean; color: string; hover
   position: absolute;
   top: 0;
   width: 0;
+  cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
 
   &:before,
   &:after {
     content: '';
     position: absolute;
     box-sizing: border-box;
-    cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
   }
 
   &:before {


### PR DESCRIPTION
사파리에서 `cursor: pointer`가 안먹는 오류 수정.

* `cursor`속성을 input 박스로 속성을 옮김.