### PR TITLE
fix: modalBottomSheet 모바일에서 padding 15px되는 오류 수정

### DIFF
--- a/src/overlays/ModalBottomSheet/index.tsx
+++ b/src/overlays/ModalBottomSheet/index.tsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import styled from 'styled-components';
-import { Button, IconButton, ButtonProps } from '../../components/Button';
+import { Button, IconButton, ButtonProps, ButtonColor } from '../../components/Button';
 import { media } from '../../core/BreakPoints';
 import { gray600, gray800, white } from '../../core/Colors';
 import { elevation5 } from '../../core/ElevationStyles';
@@ -116,10 +116,7 @@ export class ModalBottomSheet extends PureComponent<ModalBottomSheetProps, State
       return opener || null;
     }
     if (!successAttributes.color) {
-      successAttributes.color = 'orange';
-    }
-    if (!cancelAttributes.color) {
-      cancelAttributes.color = 'default';
+      successAttributes.color = ButtonColor.ORANGE;
     }
 
     const clonedOpener =


### PR DESCRIPTION
* 기존에 15px로 고정하는 scrollbar 길이를 `componentDIdMount`때 계산함 (모바일에서는 15px이 안생김).
* `successColor`, `cancelColor` 삭제.

## Image
![image](https://user-images.githubusercontent.com/32216112/64593163-8ba17b00-d3e8-11e9-943a-6be7538a4856.png)

