### PR TITLE
feat: 태그인풋 사용성 개선

### DIFF
--- a/docs/formInputs/TagInput.mdx
+++ b/docs/formInputs/TagInput.mdx
@@ -20,10 +20,11 @@ import { TagInput } from '@class101/ui';
 <Playground>
   {() => {
     class Example extends React.Component {
+      
       constructor(props) {
         super(props);
         this.state = {
-          value: ['01082210886','01082230886', '01082210886', '01082210886','01082210886','01082210886', '01082210886', '01082210886','01082210886','01082210886', '01082210886', '01082210886','01082210886','01082210886', '01082210886', '01082210886']
+          value: []
         };
       }
       handleChange(newValue) {
@@ -35,9 +36,7 @@ import { TagInput } from '@class101/ui';
       }
       render() {
         return (
-          <form onSubmit={this.handleSubmit}>
-            <TagInput separator={/[, ]/gm} value={this.state.value} onChange={(value) => this.handleChange(value)} allowMessage="Enter와 ','로 구분합니다."/>
-          </form>
+          <TagInput separator="," value={this.state.value} onChange={(value) => this.handleChange(value)} allowMessage="Enter와 ','로 구분합니다."/>
         );
       }
     }

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -41,7 +41,7 @@ const Container = styled.div`
   border-radius: 3px;
   align-items: center;
   overflow: hidden;
-  height: 24px;
+  height: 28px;
 `;
 
 const Text = styled.span`

--- a/src/formInputs/InlineError/index.tsx
+++ b/src/formInputs/InlineError/index.tsx
@@ -18,7 +18,7 @@ const ColorByIntent: { [key in Intent]: string } = {
 
 export interface InlineErrorProps {
   intent?: Intent;
-  children: string;
+  children: React.ReactNode;
   icon?: React.ReactElement<IconProps> | null;
 }
 

--- a/src/formInputs/TagInput/InnerTags/index.tsx
+++ b/src/formInputs/TagInput/InnerTags/index.tsx
@@ -14,21 +14,23 @@ export default class InnerTags extends PureComponent<Props> {
     disabled: false,
   };
 
-  private handleRemoveTag = (index: number) => () => {
-    this.props.onRemove(index);
-  };
-
   public render() {
     const { value, disabled } = this.props;
 
-    return value.map((v, i) => (
-      <Tag
-        value={v}
-        key={`tag-${i}`}
-        onRemove={this.handleRemoveTag(i)}
-        disabled={disabled}
-        className="inner-tags__tag"
-      />
-    ));
+    if (value.length > 5000) {
+      return <Tag value={`${value.slice(value.length - 3, value.length).join(', ')} 포함 총 ${value.length}개`} onRemove={this.handleRemoveTag(-1)} disabled={disabled} className="inner-tags__tag" />
+    }
+
+    return (
+      <>
+        {value.map((v, i) => (
+          <Tag value={v} key={v} onRemove={this.handleRemoveTag(i)} disabled={disabled} className="inner-tags__tag" />
+        ))}
+      </>
+    );
   }
+
+  private handleRemoveTag = (index: number) => () => {
+    this.props.onRemove(index);
+  };
 }


### PR DESCRIPTION
- 5000개가 넘어갈 시 그냥 태그 하나로 모아서 보여줍니다.
- 안에서 중복처리 합니다.
![image](https://user-images.githubusercontent.com/20659160/65750764-21a50780-e144-11e9-9576-71fa6a59b5fa.png)
