### PR TITLE
feat: GridList items에 ReadonlyArray도 받도록 타이핑한다

### DIFF
--- a/src/layout/GridList/index.tsx
+++ b/src/layout/GridList/index.tsx
@@ -10,7 +10,7 @@ const generateID = createUniqIDGenerator('grid-list-');
 
 type Column = 1 | 2 | 3 | 4 | 6 | 12;
 interface Props {
-  items: any[];
+  items: any[] | ReadonlyArray<any>;
   renderItem: any;
   smColumn: Column;
   lgColumn?: Column;
@@ -25,7 +25,7 @@ export class GridList extends PureComponent<Props> {
     return (
       <Container className={className} {...divAttributes}>
         <GridListUl smColumn={smColumn}>
-          {items.map((item, index, arr) => (
+          {items.concat().map((item, index, arr) => (
             <GridListItem key={generateID()} smColumn={smColumn} lgColumn={lgColumn}>
               {renderItem(item, index, arr)}
             </GridListItem>


### PR DESCRIPTION
```
interface Props<T> {
  items: T[] | ReadonlyArray<T>;
```
위와 같이 수정하려는데 GridList를 styled 로 감싸서 사용할때 
제네릭 지원이 안되어서 이 부분 찾아보고 다시 수정할게요