### PR TITLE
feat: badge icon의 size를 number로 받았을 때는 icon이 60%을 차지하게 변경

### DIFF
--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -28,10 +28,13 @@ export class Badge extends PureComponent<BadgeProps> {
 
   public render() {
     const { className, color, backgroundColor, pill, size, icon, children } = this.props;
+    const iconSize = typeof size === 'number' ? size * 0.6 : undefined;
     return (
       <Container className={className} backgroundColor={backgroundColor} pill={pill} size={size}>
-        {icon ? <Icon>{icon}</Icon> : null}
-        <Text color={color}>{children}</Text>
+        {icon ? <Icon size={iconSize}>{icon}</Icon> : null}
+        <Text color={color} size={iconSize}>
+          {children}
+        </Text>
       </Container>
     );
   }
@@ -51,6 +54,13 @@ const containerStyle = (size: Size | number = 'md', pill: boolean = false) => {
   `;
 };
 
+const getIconWidth = (size: number) => {
+  if (Math.floor(size) % 2 === 1) {
+    return size + 1;
+  }
+  return size;
+};
+
 const Container = styled.div<BadgeTextProps>`
   ${props => containerStyle(props.size, props.pill)};
   flex: none;
@@ -62,15 +72,15 @@ const Container = styled.div<BadgeTextProps>`
   box-sizing: border-box;
 `;
 
-const Icon = styled.div`
+const Icon = styled.div<{ size?: number }>`
   margin-right: 2px;
   > svg {
-    width: 12px;
-    height: 12px;
+    width: ${props => (props.size ? getIconWidth(props.size) : 12)}px;
+    height: ${props => props.size || 12}px;
   }
 `;
 
-const Text = styled.div<{ color?: string }>`
+const Text = styled.div<{ size?: number; color?: string }>`
   ${caption2};
   display: flex;
   justify-content: center;
@@ -79,8 +89,8 @@ const Text = styled.div<{ color?: string }>`
   line-height: 1;
   color: ${props => props.color};
   > svg {
-    width: 12px;
-    height: 12px;
+    width: ${props => (props.size ? getIconWidth(props.size) : 12)}px;
+    height: ${props => props.size || 12}px;
     margin: 0 -6px;
   }
 `;


### PR DESCRIPTION
avatar에서 size를 inject받은 badge에서 icon의 사이즈까지 한번에 반영되게 하였습니다.

## Before
![image](https://user-images.githubusercontent.com/32216112/68274781-5c884c80-00ad-11ea-9102-a5874d24db8c.png)


## After
![image](https://user-images.githubusercontent.com/32216112/68274623-f8658880-00ac-11ea-9aed-a75ed6022156.png)