### PR TITLE
feat: comment click이벤트 추가 및 디자인 수정

### DIFF
--- a/docs/components/Comment.mdx
+++ b/docs/components/Comment.mdx
@@ -58,7 +58,16 @@ Comment 컴포넌트
     }
   >
     <Comment
-      avatar={<Avatar src={IMAGE_URL} />}
+      avatar={
+        <Avatar
+          src={IMAGE_URL}
+          icon={
+            <Badge backgroundColor={Colors.orange600} pill>
+              <Icon.Crown fillColor={Colors.white} />
+            </Badge>
+          }
+        />
+      }
       name="피터펜"
       timeText="1시간 전"
       leftAction={[<Comment.Action icon={<Icon.HeartOutline />} />]}

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -55,8 +55,8 @@ export class Avatar extends PureComponent<AvatarProps, AvatarState> {
     const { isError } = this.state;
 
     const avatarSize = typeof size === 'number' ? size : avatarSizeBySize[size];
-
-    const sizedIcon = icon && React.cloneElement(icon, { size: avatarSize * iconRatio });
+    const iconSize = typeof size === 'number' ? avatarSize * iconRatio : iconSizeBySize[size];
+    const sizedIcon = icon && React.cloneElement(icon, { size: iconSize });
 
     return (
       <Container onClick={onClick} size={avatarSize} className={className}>
@@ -126,8 +126,14 @@ const iconPositionByPosition: { [key in AvatarIconPosition]: FlattenSimpleInterp
 
 const avatarSizeBySize: { [key in AvatarSize]: number } = {
   [AvatarSize.LARGE]: 40,
-  [AvatarSize.MEDIUM]: 32,
-  [AvatarSize.SMALL]: 24,
+  [AvatarSize.MEDIUM]: 24,
+  [AvatarSize.SMALL]: 18,
+};
+
+const iconSizeBySize: { [key in AvatarSize]: number } = {
+  [AvatarSize.LARGE]: 20,
+  [AvatarSize.MEDIUM]: 16,
+  [AvatarSize.SMALL]: 12,
 };
 
 const Container = styled.span<{ size: number }>`

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -28,13 +28,10 @@ export class Badge extends PureComponent<BadgeProps> {
 
   public render() {
     const { className, color, backgroundColor, pill, size, icon, children } = this.props;
-    const iconSize = typeof size === 'number' ? size * 0.6 : undefined;
     return (
       <Container className={className} backgroundColor={backgroundColor} pill={pill} size={size}>
-        {icon ? <Icon size={iconSize}>{icon}</Icon> : null}
-        <Text color={color} size={iconSize}>
-          {children}
-        </Text>
+        {icon ? <Icon>{icon}</Icon> : null}
+        <Text color={color}>{children}</Text>
       </Container>
     );
   }
@@ -54,13 +51,6 @@ const containerStyle = (size: Size | number = 'md', pill: boolean = false) => {
   `;
 };
 
-const getIconWidth = (size: number) => {
-  if (Math.floor(size) % 2 === 1) {
-    return size + 1;
-  }
-  return size;
-};
-
 const Container = styled.div<BadgeTextProps>`
   ${props => containerStyle(props.size, props.pill)};
   flex: none;
@@ -75,8 +65,8 @@ const Container = styled.div<BadgeTextProps>`
 const Icon = styled.div<{ size?: number }>`
   margin-right: 2px;
   > svg {
-    width: ${props => (props.size ? getIconWidth(props.size) : 12)}px;
-    height: ${props => props.size || 12}px;
+    width: 12px;
+    height: 12px;
   }
 `;
 
@@ -89,8 +79,8 @@ const Text = styled.div<{ size?: number; color?: string }>`
   line-height: 1;
   color: ${props => props.color};
   > svg {
-    width: ${props => (props.size ? getIconWidth(props.size) : 12)}px;
-    height: ${props => props.size || 12}px;
+    width: 12px;
+    height: 12px;
     margin: 0 -6px;
   }
 `;

--- a/src/components/Comment/Action/index.tsx
+++ b/src/components/Comment/Action/index.tsx
@@ -33,7 +33,7 @@ export class CommentAction extends PureComponent<CommentActionProps> {
     return (
       <Container display={display} position={position}>
         <FilledIconButton size="xs" color="transparent" fillColor={fillColor} {...restProps} />
-        {text && <TextWrapper color={gray500}>{text}</TextWrapper>}
+        {text !== undefined && <TextWrapper color={gray500}>{text}</TextWrapper>}
         {children}
       </Container>
     );

--- a/src/components/Comment/Content/index.tsx
+++ b/src/components/Comment/Content/index.tsx
@@ -8,6 +8,7 @@ import { ButtonSize, TextButton } from '../../Button';
 interface Props {
   useLineClamp: boolean;
   maxLine: number;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
 }
 
 interface State {
@@ -28,11 +29,11 @@ export class CommentContent extends PureComponent<Props, State> {
   }
 
   public render() {
-    const { children, maxLine } = this.props;
+    const { children, maxLine, onClick } = this.props;
     const { lineClampable, lineClamped } = this.state;
     return (
       <Container>
-        <Content useLineClamp={lineClamped} maxLine={maxLine} ref={this.contentRef}>
+        <Content useLineClamp={lineClamped} maxLine={maxLine} ref={this.contentRef} onClick={onClick}>
           {children}
         </Content>
         {lineClampable && (
@@ -63,11 +64,12 @@ export class CommentContent extends PureComponent<Props, State> {
     return false;
   };
 
-  private handleToggleClampButton = () => {
+  private handleToggleClampButton: React.MouseEventHandler = event => {
     const { lineClamped } = this.state;
     this.setState({
       lineClamped: !lineClamped,
     });
+    event.stopPropagation();
   };
 }
 

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -2,7 +2,7 @@ import React, { PureComponent, ReactElement, ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { Caption1, Caption2 } from '../../core';
-import { gray600, orange600 } from '../../core/Colors';
+import { gray500, orange600 } from '../../core/Colors';
 import { Avatar, AvatarProps, AvatarSize } from '../Avatar';
 import { ButtonIconPosition } from '../Button/ButtonIcon';
 import { CommentAction, CommentActionProps } from './Action';
@@ -34,6 +34,9 @@ export interface CommentProps {
   rightAction?: ReactElement<CommentActionProps>[];
   content?: ReactNode;
   className?: string;
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
+  onContentClick?: React.MouseEventHandler<HTMLDivElement>;
+  passingClickEventClampButton?: boolean;
 }
 
 const CommentImage = styled.img`
@@ -68,8 +71,10 @@ export class Comment extends PureComponent<CommentProps> {
       showChildren,
       maxLine = size === CommentSize.SMALL ? 2 : 4,
       className,
+      onClick,
+      onContentClick,
     } = this.props;
-    const avatarSize = size === CommentSize.LARGE ? AvatarSize.LARGE : AvatarSize.SMALL;
+    const avatarSize = size === CommentSize.LARGE ? AvatarSize.LARGE : AvatarSize.MEDIUM;
     const clonedAvatar = avatar ? (
       React.cloneElement(avatar, {
         size: avatarSize,
@@ -79,7 +84,7 @@ export class Comment extends PureComponent<CommentProps> {
     );
 
     return (
-      <Container width={width} className={className}>
+      <Container width={width} className={className} onClick={onClick}>
         <AvatarWrapper>{clonedAvatar}</AvatarWrapper>
         <ContentContainer>
           <TitleContainer>
@@ -87,17 +92,17 @@ export class Comment extends PureComponent<CommentProps> {
               <Caption1 fontWeight="600">{name}</Caption1>
               {nameDescription && <NameDescription>{nameDescription}</NameDescription>}
             </NameContainer>
-            <Caption1 color={gray600}>{timeText}</Caption1>
+            <Caption2 color={gray500}>{timeText}</Caption2>
           </TitleContainer>
-          <CommentContent useLineClamp={!disableLineClamp} maxLine={maxLine}>
+          <CommentContent useLineClamp={!disableLineClamp} maxLine={maxLine} onClick={onContentClick}>
             {content}
           </CommentContent>
           <ActionWrapper>
-            <LeftActionContainer>
+            <LeftActionContainer onClick={this.preventPropagation}>
               {leftAction &&
                 leftAction.map((action, key) => React.cloneElement(action, { position: ButtonIconPosition.LEFT, key }))}
             </LeftActionContainer>
-            <RightActionContainer>
+            <RightActionContainer onClick={this.preventPropagation}>
               {rightAction &&
                 rightAction.map((action, key) =>
                   React.cloneElement(action, { position: ButtonIconPosition.RIGHT, key })
@@ -119,6 +124,10 @@ export class Comment extends PureComponent<CommentProps> {
       </Container>
     );
   }
+
+  private preventPropagation: React.MouseEventHandler<HTMLDivElement> = event => {
+    event.stopPropagation();
+  };
 }
 
 const Container = styled.div<{ width: string }>`
@@ -134,7 +143,6 @@ const AvatarWrapper = styled.div`
 
 const ContentContainer = styled.div`
   display: flex;
-  margin-top: 4px;
   margin-left: 8px;
   flex: 1 1 auto;
   flex-direction: column;
@@ -143,14 +151,12 @@ const ContentContainer = styled.div`
 const NameContainer = styled.div`
   display: flex;
   flex-direction: row;
-  padding: 2px;
   align-items: flex-end;
 `;
 
 const TitleContainer = styled.div`
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
 `;
 
 const NameDescription = styled(Caption2)`


### PR DESCRIPTION
* Badge의 icon 크기를 12px로 고정
* Avatar의 icon 크기를 lg, md, sm에서 정해진 픽셀로 되게 수정 (숫자일때는 그대로)
* Comment에 onClick과 onContentClick 이벤트 추가
* 몇몇 action 버튼을 이벤트에서 제외하기 위해 stopPropagation 추가

## Before
![image](https://user-images.githubusercontent.com/32216112/68759685-857f8300-0653-11ea-9e5f-5fd98b5b0f75.png)

## After
![image](https://user-images.githubusercontent.com/32216112/68759699-8ca69100-0653-11ea-9a47-37c76e1422bd.png)
