### PR TITLE
feat(ui): Avatar의 이미지를 좀 더 보기 좋게 변경

### DIFF
--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -154,6 +154,7 @@ const AvatarImage = styled.img`
   border-radius: 50%;
   height: 100%;
   display: block;
+  object-fit: cover;
 `;
 
 const TextWrapper = styled.span`


### PR DESCRIPTION
Issue: #183

사내 리포에서 크리에이터 센터의 Gnb쪽에 새롭게 프로필 기능 넣다가 발견한건데 현재는 Image컴포넌트 쓰는데
Avatar이거 쓰는게 맞는거 같아서 PR쐈습니다 

바뀐후 &#8628;
<img width="1790" alt="스크린샷 2020-02-04 오전 2 19 16" src="https://user-images.githubusercontent.com/15892571/73674876-c3d98b00-46f4-11ea-8575-c6afef052f94.png">