### PR TITLE
feat(ui, mdx): Pagination에 많은 데이터가 들어와도 적당히 대응 가능하게 수정

### DIFF
--- a/docs/components/Pagination.mdx
+++ b/docs/components/Pagination.mdx
@@ -4,6 +4,7 @@ name: Pagination
 route: /components/pagination
 ---
 
+import { useState } from 'react'
 import { Playground, PropsTable } from 'docz';
 import { Pagination } from '@class101/ui';
 import { PlayGroundContainer, ThemeProvider } from '../docsComponents';
@@ -22,4 +23,14 @@ import { PlayGroundContainer, ThemeProvider } from '../docsComponents';
   <PlayGroundContainer>
     <Pagination currentPageIndex={0} totalPageIndex={1} onChange={number => alert(number)} />
   </PlayGroundContainer>
+</Playground>
+
+## With Many Datas
+<Playground>
+  {() => {
+    const [currentPageIndex, setCurrentPageIndex] = useState(0);
+    return (
+      <Pagination currentPageIndex={currentPageIndex} totalPageIndex={8} onChange={number => setCurrentPageIndex(number)} />
+    )
+  }}
 </Playground>

--- a/docs/components/Pagination.mdx
+++ b/docs/components/Pagination.mdx
@@ -37,7 +37,7 @@ import { PlayGroundContainer, ThemeProvider } from '../docsComponents';
 
 ## Assigning how many numbered index buttons to be shown
 You can assign how many numbered index buttons to be showing by passing down
-`number` to the `showingNumberedIndexButtonCount` prop. It should be an odd
+`number` to the `pageCountPerView` prop. It should be an odd
 number since the focused button needs to be centered
 
 <Playground>
@@ -47,7 +47,7 @@ number since the focused button needs to be centered
       <Pagination
         currentPageIndex={currentPageIndex}
         totalPageIndex={15}
-        showingNumberedIndexButtonCount={9}
+        pageCountPerView={9}
         onChange={number => setCurrentPageIndex(number)}
       />
     )

--- a/docs/components/Pagination.mdx
+++ b/docs/components/Pagination.mdx
@@ -34,3 +34,22 @@ import { PlayGroundContainer, ThemeProvider } from '../docsComponents';
     )
   }}
 </Playground>
+
+## Assigning how many numbered index buttons to be shown
+You can assign how many numbered index buttons to be showing by passing down
+`number` to the `showingNumberedIndexButtonCount` prop. It should be an odd
+number since the focused button needs to be centered
+
+<Playground>
+  {() => {
+    const [currentPageIndex, setCurrentPageIndex] = useState(0);
+    return (
+      <Pagination
+        currentPageIndex={currentPageIndex}
+        totalPageIndex={15}
+        showingNumberedIndexButtonCount={9}
+        onChange={number => setCurrentPageIndex(number)}
+      />
+    )
+  }}
+</Playground>

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -22,12 +22,16 @@ export class Pagination extends PureComponent<PaginationProps> {
       this.props.showingNumberedIndexButtonCount
     );
 
-    const indexList = this.getIndexList(currentPageIndex, totalPageIndex, showingNumberedIndexButtonCount);
+    const indexListToDisplay = this.getIndexListToDisplay(
+      currentPageIndex,
+      totalPageIndex,
+      showingNumberedIndexButtonCount
+    );
 
     return (
       <PageWrapper>
         <PageIconBtn icon={<ChevronLeft />} onClick={handleDecrease} disabled={currentPageIndex <= 0} />
-        {indexList.map(index => (
+        {indexListToDisplay.map(index => (
           <PageBtn
             color={index === currentPageIndex ? ButtonColor.ORANGE : ButtonColor.WHITE}
             size="sm"
@@ -53,7 +57,7 @@ export class Pagination extends PureComponent<PaginationProps> {
       : showingNumberedIndexButtonCount;
   };
 
-  private getIndexList = (
+  private getIndexListToDisplay = (
     currentPageIndex: number,
     totalPageIndex: number,
     showingNumberedIndexButtonCount: number

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -8,6 +8,7 @@ import { Button, ButtonColor, IconButton } from '../Button';
 export interface PaginationProps {
   totalPageIndex: number;
   currentPageIndex: number;
+  showingNumberedIndexButtonCount?: number;
   onChange?: (pageIndex: number) => void;
 }
 
@@ -17,7 +18,11 @@ export class Pagination extends PureComponent<PaginationProps> {
     const handleIncrease = this.handleChange(currentPageIndex + 1);
     const handleDecrease = this.handleChange(currentPageIndex - 1);
 
-    const indexList = this.getIndexList(currentPageIndex, totalPageIndex);
+    const showingNumberedIndexButtonCount = this.getValidatedShowingNumberedIndexButtonCount(
+      this.props.showingNumberedIndexButtonCount
+    );
+
+    const indexList = this.getIndexList(currentPageIndex, totalPageIndex, showingNumberedIndexButtonCount);
 
     return (
       <PageWrapper>
@@ -37,24 +42,48 @@ export class Pagination extends PureComponent<PaginationProps> {
     );
   }
 
-  private getIndexList = (currentPageIndex: number, totalPageIndex: number) => {
+  // currentPageIndex가 중앙에 보여지는 상황 때문에 홀수만 받습니다.
+  private getValidatedShowingNumberedIndexButtonCount = (showingNumberedIndexButtonCount: number | undefined) => {
+    if (!showingNumberedIndexButtonCount) {
+      return 5;
+    }
+
+    return showingNumberedIndexButtonCount % 2 === 0
+      ? showingNumberedIndexButtonCount - 1
+      : showingNumberedIndexButtonCount;
+  };
+
+  private getIndexList = (
+    currentPageIndex: number,
+    totalPageIndex: number,
+    showingNumberedIndexButtonCount: number
+  ) => {
+    /**
+     * currentPageIndex가 중앙에서 보여질때 양옆으로 몇개까지 보여주어야 하는지 계산. 보여주어야 할 numbered
+     * index가 5개이면 양옆에는 2개씩 9개라면 4개씩
+     */
+    const aroundCurrentNumberedIndexShowingCount = Math.floor(showingNumberedIndexButtonCount / 2);
+
     // 보여줄수 있는거 다 보여주기
-    if (totalPageIndex < 5) {
+    if (totalPageIndex < showingNumberedIndexButtonCount) {
       return range(0, totalPageIndex + 1);
     }
 
-    // 맨 앞에서부터 5개 보여주기
-    if (currentPageIndex - 2 <= 0) {
-      return range(0, 5);
+    // 맨 앞에서부터 보여 주어야 할 만큼 보여주기
+    if (currentPageIndex - aroundCurrentNumberedIndexShowingCount <= 0) {
+      return range(0, showingNumberedIndexButtonCount);
     }
 
-    // 맨 뒤에서부터 5개 보여주기
-    if (currentPageIndex + 2 >= totalPageIndex) {
-      return range(totalPageIndex - 4, totalPageIndex + 1);
+    // 맨 뒤에서부터 보여 주어야 할 만큼 보여주기
+    if (currentPageIndex + aroundCurrentNumberedIndexShowingCount >= totalPageIndex) {
+      return range(totalPageIndex - showingNumberedIndexButtonCount + 1, totalPageIndex + 1);
     }
 
-    // currentPageIndex와 앞뒤 2개씩 보여주기
-    return range(currentPageIndex - 2, currentPageIndex + 3);
+    // currentPageIndex와 앞뒤 보여 주어야 할 만큼 보여주기
+    return range(
+      currentPageIndex - aroundCurrentNumberedIndexShowingCount,
+      currentPageIndex + aroundCurrentNumberedIndexShowingCount + 1
+    );
   };
 
   private handleChange = (pageIndex: number) => () => {

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -19,7 +19,7 @@ export class Pagination extends PureComponent<PaginationProps> {
     const handleIncrease = this.handleChange(currentPageIndex + 1);
     const handleDecrease = this.handleChange(currentPageIndex - 1);
 
-    const pageCountPerView = this.getValidatedShowingNumberedIndexButtonCount(this.props.pageCountPerView);
+    const pageCountPerView = this.getValidatedPageCountPerView(this.props.pageCountPerView);
     const indexListToDisplay = this.getIndexListToDisplay(currentPageIndex, totalPageIndex, pageCountPerView);
 
     return (
@@ -40,7 +40,7 @@ export class Pagination extends PureComponent<PaginationProps> {
     );
   }
 
-  private getValidatedShowingNumberedIndexButtonCount = (pageCountPerView: number | undefined) => {
+  private getValidatedPageCountPerView = (pageCountPerView: number | undefined) => {
     if (!pageCountPerView) {
       return DEFAULT_PAGE_COUNT_PER_VIEW;
     }

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -17,25 +17,45 @@ export class Pagination extends PureComponent<PaginationProps> {
     const handleIncrease = this.handleChange(currentPageIndex + 1);
     const handleDecrease = this.handleChange(currentPageIndex - 1);
 
-    const indexList = range(0, totalPageIndex + 1);
+    const indexList = this.getIndexList(currentPageIndex, totalPageIndex);
 
     return (
       <PageWrapper>
         <PageIconBtn icon={<ChevronLeft />} onClick={handleDecrease} disabled={currentPageIndex <= 0} />
-        {indexList.map((_, i) => (
+        {indexList.map(index => (
           <PageBtn
-            color={i === currentPageIndex ? ButtonColor.ORANGE : ButtonColor.WHITE}
+            color={index === currentPageIndex ? ButtonColor.ORANGE : ButtonColor.WHITE}
             size="sm"
-            onClick={this.handleChange(i)}
-            key={`pagination-${i}`}
+            onClick={this.handleChange(index)}
+            key={`pagination-${index}`}
           >
-            {i + 1}
+            {index + 1}
           </PageBtn>
         ))}
         <PageIconBtn icon={<ChevronRight />} onClick={handleIncrease} disabled={currentPageIndex >= totalPageIndex} />
       </PageWrapper>
     );
   }
+
+  private getIndexList = (currentPageIndex: number, totalPageIndex: number) => {
+    // 보여줄수 있는거 다 보여주기
+    if (totalPageIndex < 5) {
+      return range(0, totalPageIndex + 1);
+    }
+
+    // 맨 앞에서부터 5개 보여주기
+    if (currentPageIndex - 2 <= 0) {
+      return range(0, 5);
+    }
+
+    // 맨 뒤에서부터 5개 보여주기
+    if (currentPageIndex + 2 >= totalPageIndex) {
+      return range(totalPageIndex - 4, totalPageIndex + 1);
+    }
+
+    // currentPageIndex와 앞뒤 2개씩 보여주기
+    return range(currentPageIndex - 2, currentPageIndex + 3);
+  };
 
   private handleChange = (pageIndex: number) => () => {
     const { onChange } = this.props;

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -5,10 +5,11 @@ import styled, { css } from 'styled-components';
 import { ChevronLeft, ChevronRight } from '../../Icon';
 import { Button, ButtonColor, IconButton } from '../Button';
 
+const DEFAULT_PAGE_COUNT_PER_VIEW = 5;
 export interface PaginationProps {
   totalPageIndex: number;
   currentPageIndex: number;
-  showingNumberedIndexButtonCount?: number;
+  pageCountPerView?: number;
   onChange?: (pageIndex: number) => void;
 }
 
@@ -18,15 +19,8 @@ export class Pagination extends PureComponent<PaginationProps> {
     const handleIncrease = this.handleChange(currentPageIndex + 1);
     const handleDecrease = this.handleChange(currentPageIndex - 1);
 
-    const showingNumberedIndexButtonCount = this.getValidatedShowingNumberedIndexButtonCount(
-      this.props.showingNumberedIndexButtonCount
-    );
-
-    const indexListToDisplay = this.getIndexListToDisplay(
-      currentPageIndex,
-      totalPageIndex,
-      showingNumberedIndexButtonCount
-    );
+    const pageCountPerView = this.getValidatedShowingNumberedIndexButtonCount(this.props.pageCountPerView);
+    const indexListToDisplay = this.getIndexListToDisplay(currentPageIndex, totalPageIndex, pageCountPerView);
 
     return (
       <PageWrapper>
@@ -46,48 +40,30 @@ export class Pagination extends PureComponent<PaginationProps> {
     );
   }
 
-  // currentPageIndex가 중앙에 보여지는 상황 때문에 홀수만 받습니다.
-  private getValidatedShowingNumberedIndexButtonCount = (showingNumberedIndexButtonCount: number | undefined) => {
-    if (!showingNumberedIndexButtonCount) {
-      return 5;
+  private getValidatedShowingNumberedIndexButtonCount = (pageCountPerView: number | undefined) => {
+    if (!pageCountPerView) {
+      return DEFAULT_PAGE_COUNT_PER_VIEW;
     }
 
-    return showingNumberedIndexButtonCount % 2 === 0
-      ? showingNumberedIndexButtonCount - 1
-      : showingNumberedIndexButtonCount;
+    return pageCountPerView % 2 === 0 ? pageCountPerView - 1 : pageCountPerView;
   };
 
-  private getIndexListToDisplay = (
-    currentPageIndex: number,
-    totalPageIndex: number,
-    showingNumberedIndexButtonCount: number
-  ) => {
-    /**
-     * currentPageIndex가 중앙에서 보여질때 양옆으로 몇개까지 보여주어야 하는지 계산. 보여주어야 할 numbered
-     * index가 5개이면 양옆에는 2개씩 9개라면 4개씩
-     */
-    const aroundCurrentNumberedIndexShowingCount = Math.floor(showingNumberedIndexButtonCount / 2);
+  private getIndexListToDisplay = (currentPageIndex: number, totalPageIndex: number, pageCountPerView: number) => {
+    const sidePageCountToView = Math.floor(pageCountPerView / 2);
 
-    // 보여줄수 있는거 다 보여주기
-    if (totalPageIndex < showingNumberedIndexButtonCount) {
+    if (totalPageIndex < pageCountPerView) {
       return range(0, totalPageIndex + 1);
     }
 
-    // 맨 앞에서부터 보여 주어야 할 만큼 보여주기
-    if (currentPageIndex - aroundCurrentNumberedIndexShowingCount <= 0) {
-      return range(0, showingNumberedIndexButtonCount);
+    if (currentPageIndex <= sidePageCountToView) {
+      return range(0, pageCountPerView);
     }
 
-    // 맨 뒤에서부터 보여 주어야 할 만큼 보여주기
-    if (currentPageIndex + aroundCurrentNumberedIndexShowingCount >= totalPageIndex) {
-      return range(totalPageIndex - showingNumberedIndexButtonCount + 1, totalPageIndex + 1);
+    if (currentPageIndex + sidePageCountToView >= totalPageIndex) {
+      return range(totalPageIndex - pageCountPerView + 1, totalPageIndex + 1);
     }
 
-    // currentPageIndex와 앞뒤 보여 주어야 할 만큼 보여주기
-    return range(
-      currentPageIndex - aroundCurrentNumberedIndexShowingCount,
-      currentPageIndex + aroundCurrentNumberedIndexShowingCount + 1
-    );
+    return range(currentPageIndex - sidePageCountToView, currentPageIndex + sidePageCountToView + 1);
   };
 
   private handleChange = (pageIndex: number) => () => {


### PR DESCRIPTION
Clickup: [23kufy](https://app.clickup.com/t/23kufy)
Figma: [Pagination component](https://www.figma.com/file/BPv3p1SEYUKhuKyYW3syfTgq/Product_System_Component?node-id=4657%3A7899)

## What I did
데이터가 많을경우 pagination numbered 버튼들을 보여주고 싶은 만큼 보여줄수 있고 맨앞/뒤쪽이 아닌이상 현재 선택된 currentPageIndex가 중앙에 보이도록 수정

## Context
쿤과 이야기를 해서 현재 가장 심플한 정도의 대응만 가능하게 수정 했습니다. 나중에 반응형또는 이걸 구현하는대에도 방법이 많이 있는데 추후에 논의 하면 될 것 같습니다.

##### 이전 &#8628;
<img width="959" alt="스크린샷 2020-02-05 오후 3 42 19" src="https://user-images.githubusercontent.com/15892571/73818088-e58b5d00-482f-11ea-8bef-0f6d9b476c7b.png">

##### 변경후 &#8628;
![화면 기록 2020-02-05 오후 3 41 26-1](https://user-images.githubusercontent.com/15892571/73818297-634f6880-4830-11ea-8f48-6fd5aa061f49.gif)
