### PR TITLE
[BREAKING CHANGE] chore: class101/ui 9.0.0-rc0

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,10 @@
 {
   "presets": [["@babel/preset-env", { "modules": false }], "@babel/preset-react"],
   "plugins": [
-    ["@babel/proposal-class-properties"],
-    ["@babel/plugin-proposal-object-rest-spread"],
-    ["@babel/plugin-proposal-nullish-coalescing-operator"],
-    ["@babel/plugin-proposal-optional-chaining"]
+    "@babel/proposal-class-properties",
+    "@babel/plugin-proposal-object-rest-spread",
+    "@babel/plugin-proposal-nullish-coalescing-operator",
+    "@babel/plugin-proposal-optional-chaining"
   ],
   "env": {
     "test": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "test": "cross-env CI=1 react-scripts-ts test --env=jsdom",
     "test:watch": "react-scripts-ts test --env=jsdom",
-    "build": "docz build",
+    "build": "docz build && dist-size ./dist",
     "prebuild": "tsc -p . && rollup -c",
     "start": "rollup -c -w",
     "predeploy": "cd example && yarn install && yarn run build",
@@ -81,6 +81,7 @@
     "@types/styled-components": "^4.4.0",
     "@types/swiper": "^4.4.5",
     "cross-env": "^5.1.4",
+    "dist-size": "^0.4.0",
     "docz": "^0.13.7",
     "docz-theme-default": "^0.12.9",
     "eslint": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "styled-components": "4.4.1",
     "tslib": "^1.9.3",
     "tslint": "^5.12.0",
-    "typescript": "^3.7.2"
+    "typescript": "3.8.3"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@class101/ui",
-  "version": "9.0.0-test2",
+  "version": "9.0.0-rc0",
   "description": "A React-based UI Component Library, powered by Class101.",
   "author": "Class101 Co, LTD.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@class101/ui",
-  "version": "8.5.1-rc0",
+  "version": "9.0.0-test2",
   "description": "A React-based UI Component Library, powered by Class101.",
   "author": "Class101 Co, LTD.",
   "license": "MIT",
@@ -9,9 +9,9 @@
     "url": "https://github.com/pedaling/class101-ui.git"
   },
   "main": "dist/index.js",
-  "module": "dist/index.es.js",
-  "jsnext:main": "dist/index.es.js",
-  "types": "dist/index.d.ts",
+  "module": "dist/esm/index.js",
+  "jsnext:main": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
   "sideEffects": false,
   "engines": {
     "node": ">=8",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:watch": "react-scripts-ts test --env=jsdom",
     "build": "docz build && dist-size ./dist",
     "prebuild": "tsc -p . && rollup -c",
+    "analyze": "cross-env RUNNING_ENV=analyze yarn prebuild",
     "start": "rollup -c -w",
     "predeploy": "cd example && yarn install && yarn run build",
     "deploy": "gh-pages -d example/build",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "test": "cross-env CI=1 react-scripts-ts test --env=jsdom",
     "test:watch": "react-scripts-ts test --env=jsdom",
-    "build": "tsc -p . && rollup -c && docz build",
+    "build": "docz build",
     "prebuild": "tsc -p . && rollup -c",
     "start": "rollup -c -w",
     "predeploy": "cd example && yarn install && yarn run build",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,11 +28,15 @@ const getPlugins = format => [
     ...(format === 'cjs' && { tsconfigOverride: { compilerOptions: { declaration: false } } }),
   }),
   commonjs({ extensions: ['.js', '.ts'] }),
-  visualizer({
-    sourcemap: false,
-    bundlesRelative: false,
-    template: 'treemap', // sunburst, treemap, circlepacking, network
-  }),
+  process.env.RUNNING_ENV === 'analyze' && format === 'cjs'
+    ? visualizer({
+        sourcemap: false,
+        bundlesRelative: false,
+        open: true,
+        gzipSize: true,
+        template: 'treemap', // sunburst, treemap, circlepacking, network
+      })
+    : undefined,
 ];
 
 export default [

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,7 +1,13 @@
-import * as BreakPoints from './BreakPoints';
-import * as Colors from './Colors';
-import * as ElevationStyles from './ElevationStyles';
-import * as TextStyles from './TextStyles';
+import * as breakPoints from './BreakPoints';
+import * as colors from './Colors';
+import * as elevationStyles from './ElevationStyles';
+import * as textStyles from './TextStyles';
+
+// MEMO: import 한 값을 변수로 할당 안 하고 바로 export할 경우 esm format 빌드할 때 rollup이 index로 이름을 바꿔버려서 output이 이상해지기 때문에 변수로 할당 한다.
+const BreakPoints = breakPoints;
+const Colors = colors;
+const ElevationStyles = elevationStyles;
+const TextStyles = textStyles;
 
 export { BreakPoints, Colors, TextStyles, ElevationStyles };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1562,6 +1562,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.136.tgz#413e85089046b865d960c9ff1d400e04c31ab60f"
   integrity sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==
 
+"@types/minimist@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
+  integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
+
 "@types/node@*":
   version "10.12.20"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.20.tgz#f79f959acd3422d0889bd1ead1664bd2d17cd367"
@@ -3719,6 +3724,18 @@ bytes@3.0.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
   integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
 
+cac@^4.0.0:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-4.4.4.tgz#dec5f3f6aae29ce988d7654e1fb3c6e8077924b1"
+  integrity sha1-3sXz9qrinOmI12VOH7PG6Ad5JLE=
+  dependencies:
+    chalk "^2.0.1"
+    minimost "^1.0.0"
+    read-pkg-up "^2.0.0"
+    redent "^2.0.0"
+    string-width "^2.1.1"
+    text-table "^0.2.0"
+
 cacache@^10.0.4:
   version "10.0.4"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-10.0.4.tgz#6452367999eff9d4188aefd9a14e9d7c6a263460"
@@ -5637,6 +5654,21 @@ dir-glob@^2.0.0, dir-glob@^2.2.1:
   integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
   dependencies:
     path-type "^3.0.0"
+
+dist-size@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/dist-size/-/dist-size-0.4.0.tgz#c1a45a0e9c7625e9dd9491b48f09c5ebbf6d6e11"
+  integrity sha512-06JxCMOxxJ2dChQXo+1RtRBiY8EOhHsjOh+oDjfUp3hJPqC3fuNUmjA8htPDhzPHrHIZjg17Wjnk8xbfFyfWPQ==
+  dependencies:
+    cac "^4.0.0"
+    chalk "^2.0.1"
+    globby "^6.1.0"
+    gzip-size "^3.0.0"
+    pify "^3.0.0"
+    pretty-bytes "^4.0.2"
+    string-width "^2.1.1"
+    text-table "^0.2.0"
+    update-notifier "^2.2.0"
 
 dns-equal@^1.0.0:
   version "1.0.0"
@@ -7914,7 +7946,7 @@ gud@^1.0.0:
   resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
   integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
 
-gzip-size@3.0.0:
+gzip-size@3.0.0, gzip-size@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
   integrity sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=
@@ -11267,6 +11299,14 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
+
+minimost@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/minimost/-/minimost-1.2.0.tgz#a37f91d60395fc003180d208ca9e0316bcc4e3a2"
+  integrity sha512-/+eWyOtXw41WIUV9rBgrXna11bxbqymebSeW2arsfp/MCGCwe+2czzsOueEtLZgH4xb4QXhje5H9MLCsCPibLA==
+  dependencies:
+    "@types/minimist" "^1.2.0"
+    minimist "^1.2.0"
 
 minipass@^2.2.1, minipass@^2.3.3, minipass@^2.3.4:
   version "2.3.5"
@@ -17361,7 +17401,7 @@ upath@^1.0.5:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
   integrity sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==
 
-update-notifier@^2.3.0, update-notifier@^2.5.0:
+update-notifier@^2.2.0, update-notifier@^2.3.0, update-notifier@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
   integrity sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -17096,10 +17096,10 @@ typescript@3.1.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
   integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
 
-typescript@^3.7.2:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
-  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
## Change Log 
- `module`, `jsnext:main`, `types` entry file 경로 수정
- typescript 버전 3.8.3으로 업그레이드
- es format 빌드일 때 한개의 파일로 번들링 하지않고 파일 단위로 빌드되게 변경해서 웹팩 트리쉐이킹 이슈 수정
- yarn build 커맨드를 입력 했을 때 rollup, typescript 컴파일 2번 돌던 문제 수정
- 빌드 된 다음 cli 상에서 output의 normal size와 gzip size 표시되게 변경
- build된 파일에 dependency 패키지를 포함 안 하게 변경(Unpacked Size: 3.3MB => 820KB)