### PR TITLE
Refactor/carousel docs

### DIFF
--- a/docs/components/Carousel.mdx
+++ b/docs/components/Carousel.mdx
@@ -21,21 +21,13 @@ Swiper를 캡슐화한 컴포넌트 입니다.
 
 <Playground>
   <Carousel swiperProps={{ freeMode: true }}>
-    <Slide>
-      <PlayGroundBanner fill backgroundColor={Colors.red100}>
-        배너1
-      </PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner fill backgroundColor={Colors.red200}>
-        배너2
-      </PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner fill backgroundColor={Colors.red300}>
-        배너3
-      </PlayGroundBanner>
-    </Slide>
+    {[1, 2, 3].map((order) => (
+      <Slide key={`ViewAllButton-${order}`}>
+        <PlayGroundBanner fill backgroundColor={Colors[`red${order * 100}`]}>
+          배너{order}
+        </PlayGroundBanner>
+      </Slide>
+    ))}
   </Carousel>
 </Playground>
 
@@ -63,42 +55,13 @@ enum CarouselNavigationPosition {
       smSlidesPerView={2}
       pagination
     >
-      <Slide>
-        <PlayGroundBanner backgroundColor={Colors.blue100}>배너1</PlayGroundBanner>
-      </Slide>
-      <Slide>
-        <PlayGroundBanner backgroundColor={Colors.blue200}>배너2</PlayGroundBanner>
-      </Slide>
-      <Slide>
-        <PlayGroundBanner backgroundColor={Colors.blue300}>배너3</PlayGroundBanner>
-      </Slide>
-      <Slide>
-        <PlayGroundBanner backgroundColor={Colors.blue400}>배너4</PlayGroundBanner>
-      </Slide>
-      <Slide>
-        <PlayGroundBanner backgroundColor={Colors.blue500}>배너5</PlayGroundBanner>
-      </Slide>
-      <Slide>
-        <PlayGroundBanner backgroundColor={Colors.blue600}>배너6</PlayGroundBanner>
-      </Slide>
-      <Slide>
-        <PlayGroundBanner backgroundColor={Colors.blue100}>배너7</PlayGroundBanner>
-      </Slide>
-      <Slide>
-        <PlayGroundBanner backgroundColor={Colors.blue200}>배너8</PlayGroundBanner>
-      </Slide>
-      <Slide>
-        <PlayGroundBanner backgroundColor={Colors.blue300}>배너9</PlayGroundBanner>
-      </Slide>
-      <Slide>
-        <PlayGroundBanner backgroundColor={Colors.blue400}>배너10</PlayGroundBanner>
-      </Slide>
-      <Slide>
-        <PlayGroundBanner backgroundColor={Colors.blue500}>배너11</PlayGroundBanner>
-      </Slide>
-      <Slide>
-        <PlayGroundBanner backgroundColor={Colors.blue600}>배너12</PlayGroundBanner>
-      </Slide>
+      {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map((order) => (
+        <Slide key={`ViewAllButton-${order}`}>
+          <PlayGroundBanner backgroundColor={Colors[`blue${(((order - 1) % 6) + 1) * 100}`]}>
+            배너{order}
+          </PlayGroundBanner>
+        </Slide>
+      ))}
     </Carousel>
   </Section>
 </Playground>
@@ -112,24 +75,11 @@ enum CarouselNavigationPosition {
     smSlidesPerView={2}
     pagination
   >
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue100}>배너1</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue200}>배너2</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue300}>배너3</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue400}>배너4</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue500}>배너5</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue600}>배너6</PlayGroundBanner>
-    </Slide>
+    {[1, 2, 3, 4, 5, 6].map((order) => (
+      <Slide key={`ViewAllButton-${order}`}>
+        <PlayGroundBanner backgroundColor={Colors[`blue${order * 100}`]}>배너{order}</PlayGroundBanner>
+      </Slide>
+    ))}
   </Carousel>
 </Playground>
 
@@ -141,24 +91,11 @@ enum CarouselNavigationPosition {
     paginationTheme={CarouselPaginationTheme.Light}
     pagination
   >
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue100}>배너1</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue200}>배너2</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue300}>배너3</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue400}>배너4</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue500}>배너5</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue600}>배너6</PlayGroundBanner>
-    </Slide>
+    {[1, 2, 3, 4, 5, 6].map((order) => (
+      <Slide key={`ViewAllButton-${order}`}>
+        <PlayGroundBanner backgroundColor={Colors[`blue${order * 100}`]}>배너{order}</PlayGroundBanner>
+      </Slide>
+    ))}
   </Carousel>
 </Playground>
 
@@ -166,26 +103,16 @@ enum CarouselNavigationPosition {
 
 <Playground>
   <Carousel navigationPosition={CarouselNavigationPosition.BottomRightIn} containerContentMaxWidth={560}>
-    <Slide>
+    <Slide key={`ViewAllButton-1`}>
       <PlayGroundBanner backgroundColor={Colors.blue100} style={{ display: 'flex', justifyContent: 'center' }}>
         <div style={{ width: '100%', maxWidth: 560, backgroundColor: 'yellow', height: 100 }}>배너1</div>
       </PlayGroundBanner>
     </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue200}>배너2</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue300}>배너3</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue400}>배너4</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue500}>배너5</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue600}>배너6</PlayGroundBanner>
-    </Slide>
+    {[2, 3, 4, 5, 6].map((order) => (
+      <Slide key={`ViewAllButton-${order}`}>
+        <PlayGroundBanner backgroundColor={Colors[`blue${order * 100}`]}>배너{order}</PlayGroundBanner>
+      </Slide>
+    ))}
   </Carousel>
 </Playground>
 
@@ -205,21 +132,13 @@ enum CarouselPaginationTheme {
     swiperProps={{ freeMode: false }}
     pagination
   >
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.red100} onClick={() => alert('clicked')}>
-        배너1
-      </PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.red200} onClick={() => alert('clicked')}>
-        배너2
-      </PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.red300} onClick={() => alert('clicked')}>
-        배너3
-      </PlayGroundBanner>
-    </Slide>
+    {[1, 2, 3].map((order) => (
+      <Slide key={`ViewAllButton-${order}`}>
+        <PlayGroundBanner backgroundColor={Colors[`red${order * 100}`]} onClick={() => alert('clicked')}>
+          배너{order}
+        </PlayGroundBanner>
+      </Slide>
+    ))}
   </Carousel>
   <Carousel
     navigationPosition={CarouselNavigationPosition.BottomRightIn}
@@ -227,15 +146,11 @@ enum CarouselPaginationTheme {
     swiperProps={{ freeMode: false }}
     pagination
   >
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue100}>배너1</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue200}>배너2</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue300}>배너3</PlayGroundBanner>
-    </Slide>
+    {[1, 2, 3].map((order) => (
+      <Slide key={`ViewAllButton-${order}`}>
+        <PlayGroundBanner backgroundColor={Colors[`blue${order * 100}`]}>배너{order}</PlayGroundBanner>
+      </Slide>
+    ))}
   </Carousel>
 </Playground>
 
@@ -248,15 +163,11 @@ enum CarouselPaginationTheme {
     swiperProps={{ freeMode: true, loop: true }}
     pagination
   >
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue100}>배너1</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue200}>배너2</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue300}>배너3</PlayGroundBanner>
-    </Slide>
+    {[1, 2, 3].map((order) => (
+      <Slide key={`ViewAllButton-${order}`}>
+        <PlayGroundBanner backgroundColor={Colors[`blue${order * 100}`]}>배너{order}</PlayGroundBanner>
+      </Slide>
+    ))}
   </Carousel>
   <Carousel
     navigationPosition={CarouselNavigationPosition.BottomRightIn}
@@ -264,15 +175,11 @@ enum CarouselPaginationTheme {
     swiperProps={{ freeMode: false, loop: true }}
     pagination
   >
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue100}>배너1</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue200}>배너2</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue300}>배너3</PlayGroundBanner>
-    </Slide>
+    {[1, 2, 3].map((order) => (
+      <Slide key={`ViewAllButton-${order}`}>
+        <PlayGroundBanner backgroundColor={Colors[`blue${order * 100}`]}>배너{order}</PlayGroundBanner>
+      </Slide>
+    ))}
   </Carousel>
 </Playground>
 
@@ -292,15 +199,11 @@ enum CarouselPaginationTheme {
     }}
     pagination
   >
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue100}>배너1</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue200}>배너2</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue300}>배너3</PlayGroundBanner>
-    </Slide>
+    {[1, 2, 3].map((order) => (
+      <Slide key={`ViewAllButton-${order}`}>
+        <PlayGroundBanner backgroundColor={Colors[`blue${order * 100}`]}>배너{order}</PlayGroundBanner>
+      </Slide>
+    ))}
   </Carousel>
 </Playground>
 
@@ -319,30 +222,11 @@ enum CarouselPaginationTheme {
     slideToClickedSlide
     pagination
   >
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue100}>배너1</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue200}>배너2</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue300}>배너3</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue300}>배너3</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue400}>배너4</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue500}>배너5</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue600}>배너6</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.blue700}>배너7</PlayGroundBanner>
-    </Slide>
+    {[1, 2, 3, 4, 5, 6, 7].map((order) => (
+      <Slide key={`ViewAllButton-${order}`}>
+        <PlayGroundBanner backgroundColor={Colors[`blue${order * 100}`]}>배너{order}</PlayGroundBanner>
+      </Slide>
+    ))}
   </Carousel>
 </Playground>
 
@@ -356,24 +240,11 @@ enum CarouselPaginationTheme {
       smSlidesPerView={2}
       pagination
     >
-      <Slide>
-        <PlayGroundBanner backgroundColor={Colors.blue100}>배너1</PlayGroundBanner>
-      </Slide>
-      <Slide>
-        <PlayGroundBanner backgroundColor={Colors.blue200}>배너2</PlayGroundBanner>
-      </Slide>
-      <Slide>
-        <PlayGroundBanner backgroundColor={Colors.blue300}>배너3</PlayGroundBanner>
-      </Slide>
-      <Slide>
-        <PlayGroundBanner backgroundColor={Colors.blue400}>배너4</PlayGroundBanner>
-      </Slide>
-      <Slide>
-        <PlayGroundBanner backgroundColor={Colors.blue500}>배너5</PlayGroundBanner>
-      </Slide>
-      <Slide>
-        <PlayGroundBanner backgroundColor={Colors.blue600}>배너6</PlayGroundBanner>
-      </Slide>
+      {[1, 2, 3, 4, 5, 6].map((order) => (
+        <Slide key={`ViewAllButton-${order}`}>
+          <PlayGroundBanner backgroundColor={Colors[`blue${order * 100}`]}>배너{order}</PlayGroundBanner>
+        </Slide>
+      ))}
       <Carousel.ViewAllButton />
     </Carousel>
   </Section>
@@ -394,24 +265,11 @@ enum CarouselPaginationTheme {
         smSlidesSideOffset={24}
         pagination
       >
-        <Slide>
-          <PlayGroundBanner backgroundColor={Colors.blue100}>배너1</PlayGroundBanner>
-        </Slide>
-        <Slide>
-          <PlayGroundBanner backgroundColor={Colors.blue200}>배너2</PlayGroundBanner>
-        </Slide>
-        <Slide>
-          <PlayGroundBanner backgroundColor={Colors.blue300}>배너3</PlayGroundBanner>
-        </Slide>
-        <Slide>
-          <PlayGroundBanner backgroundColor={Colors.blue400}>배너4</PlayGroundBanner>
-        </Slide>
-        <Slide>
-          <PlayGroundBanner backgroundColor={Colors.blue500}>배너5</PlayGroundBanner>
-        </Slide>
-        <Slide>
-          <PlayGroundBanner backgroundColor={Colors.blue600}>배너6</PlayGroundBanner>
-        </Slide>
+        {[1, 2, 3, 4, 5, 6].map((order) => (
+          <Slide key={`ViewAllButton-${order}`}>
+            <PlayGroundBanner backgroundColor={Colors[`blue${order * 100}`]}>배너{order}</PlayGroundBanner>
+          </Slide>
+        ))}
       </Carousel>
     </PlayGroundSectionCarouselContent>
   </Section>
@@ -423,15 +281,11 @@ slidesPerView 값이 1일 경우 기본적으로 spaceBetween 값은 0입니다.
 
 <Playground>
   <Carousel lgSpaceBetween lgSlidesSideOffset={32} smSpaceBetween smSlidesSideOffset={24}>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.red100}>배너1</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.red200}>배너2</PlayGroundBanner>
-    </Slide>
-    <Slide>
-      <PlayGroundBanner backgroundColor={Colors.red300}>배너3</PlayGroundBanner>
-    </Slide>
+    {[1, 2, 3].map((order) => (
+      <Slide key={`ViewAllButton-${order}`}>
+        <PlayGroundBanner backgroundColor={Colors[`red${order * 100}`]}>배너{order}</PlayGroundBanner>
+      </Slide>
+    ))}
   </Carousel>
 </Playground>
 
@@ -445,9 +299,11 @@ slidesPerView 값이 1일 경우 기본적으로 spaceBetween 값은 0입니다.
     return (
       <div>
         <Carousel onChangeSlide={setCurrentIndex} activeIndex={currentIndex}>
-          <Slide><PlayGroundBanner backgroundColor={Colors.red100}>배너1</PlayGroundBanner></Slide>
-          <Slide><PlayGroundBanner backgroundColor={Colors.red200}>배너2</PlayGroundBanner></Slide>
-          <Slide><PlayGroundBanner backgroundColor={Colors.red300}>배너3</PlayGroundBanner></Slide>
+          {[1, 2, 3].map((order) => (
+            <Slide key={`ViewAllButton-${order}`}>
+              <PlayGroundBanner backgroundColor={Colors[`red${order * 100}`]}>배너{order}</PlayGroundBanner>
+            </Slide>
+          ))}
         </Carousel>
         <div>
           <button onClick={() => setCurrentIndex(0)}>1 {currentIndex === 0 && 'active!!'}</button>
@@ -466,9 +322,11 @@ loop 모드
     return (
       <div>
         <Carousel onChangeSlide={setCurrentIndex} activeIndex={currentIndex} swiperProps={{loop: true}}>
-          <Slide><PlayGroundBanner backgroundColor={Colors.red100}>배너1</PlayGroundBanner></Slide>
-          <Slide><PlayGroundBanner backgroundColor={Colors.red200}>배너2</PlayGroundBanner></Slide>
-          <Slide><PlayGroundBanner backgroundColor={Colors.red300}>배너3</PlayGroundBanner></Slide>
+          {[1, 2, 3].map((order) => (
+            <Slide key={`ViewAllButton-${order}`}>
+              <PlayGroundBanner backgroundColor={Colors[`red${order * 100}`]}>배너{order}</PlayGroundBanner>
+            </Slide>
+          ))}
         </Carousel>
         <div>
           <button onClick={() => setCurrentIndex(0)}>1 {currentIndex === 0 && 'active!!'}</button>

--- a/docs/components/Carousel.mdx
+++ b/docs/components/Carousel.mdx
@@ -295,7 +295,7 @@ slidesPerView 값이 1일 경우 기본적으로 spaceBetween 값은 0입니다.
 
 <Playground>
   {() => {
-    const [currentIndex, setCurrentIndex] = React.useState(0)
+    const [currentIndex, setCurrentIndex] = React.useState(0);
     return (
       <div>
         <Carousel onChangeSlide={setCurrentIndex} activeIndex={currentIndex}>
@@ -311,17 +311,18 @@ slidesPerView 값이 1일 경우 기본적으로 spaceBetween 값은 0입니다.
           <button onClick={() => setCurrentIndex(2)}>3 {currentIndex === 2 && 'active!!'}</button>
         </div>
       </div>
-    )}}
+    );
+  }}
 </Playground>
 
 loop 모드
 
 <Playground>
   {() => {
-    const [currentIndex, setCurrentIndex] = React.useState(0)
+    const [currentIndex, setCurrentIndex] = React.useState(0);
     return (
       <div>
-        <Carousel onChangeSlide={setCurrentIndex} activeIndex={currentIndex} swiperProps={{loop: true}}>
+        <Carousel onChangeSlide={setCurrentIndex} activeIndex={currentIndex} swiperProps={{ loop: true }}>
           {[1, 2, 3].map((order) => (
             <Slide key={`ViewAllButton-${order}`}>
               <PlayGroundBanner backgroundColor={Colors[`red${order * 100}`]}>배너{order}</PlayGroundBanner>
@@ -334,5 +335,6 @@ loop 모드
           <button onClick={() => setCurrentIndex(2)}>3 {currentIndex === 2 && 'active!!'}</button>
         </div>
       </div>
-    )}}
+    );
+  }}
 </Playground>


### PR DESCRIPTION
## PR에 대한 요약

`Carousel` 문서에서 반복적으로 보이는 코드들을 줄입니다.

## PR에 대한 동기

- 기존 문서에서는 `Slide` 와 `PlayGroundBanner` 컴포넌트의 조합으로 적게는 3개에서, 많게는 12개 까지 하드코딩 되어 있습니다.
- 수정한 문서에서 보여주고자 하는 중요한 내용은, `Carousel` 컴포넌트의 사용 법 임에도 불필요한 코드들이 매우 길게 나열되어 있어 문서를 읽는데 방해가 되는 것 같습니다.

## 해결법
- DRY 하게 가져가고, 가독성을 높이기 위해 해당 요소들을 배열의 순회를 통하여 줄입니다

## 결과물
### Before
![carousel-before](https://user-images.githubusercontent.com/8156543/79048672-ab886e00-7c59-11ea-8894-be7e5b3bb594.gif)

> *한 눈에 모든 코드를 보기 어렵습니다. 🧐*

### ✨After
<img width="1295" alt="carousel-after" src="https://user-images.githubusercontent.com/8156543/79048675-b5aa6c80-7c59-11ea-93fe-8e709c9ebeaf.png">

> *한 페이지에 모든 코드를 확인할 수 있습니다. 🤙*

## 추가적인 고려 사항

### 배열을 생성하는 방법을 수정해야 하는가 

```js
// 현재
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map(order=>{}) // order 그대로 사용

// 방법 1
new Array(12).fill(0).map((_,idx)=>{}) // idx+1 후 사용

// 방법 2
[...Array(12).keys()].map(order=>{}) // order+1 후 사용
```

### 조금 더 친절하게 작성하는 방법을 선택해야 하는가

단점: 코드의 길이가 길어짐

```jsx
// 본 PR
{
  [1, 2, 3, 4, 5, 6, 7].map(id=>(
    <Slide key={`ViewAllButton-${id}`}>
      <PlayGroundBanner backgroundColor={Colors[`blue${id*100}`]}>배너{id}</PlayGroundBanner>
    </Slide>
    )
  )
}
// 더 친절하게
{
  [1, 2, 3, 4, 5, 6, 7].map(id=>{
  const colorOption = `blue${id*100}`
  const key = `ViewAllButton-${id}`
  return (
    <Slide key={key}>
      <PlayGroundBanner backgroundColor={Colors[colorOption]}>배너{id}</PlayGroundBanner>
    </Slide>
    )
  })
}
```

