### PR TITLE
fix(ui): docz PropsTable이 정상적으로 표시되도록 수정한다.

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -8,6 +8,14 @@ export default {
   src: './docs/',
   dest: './public',
   public: '/pub',
+  docgenConfig: {
+    searchPatterns: [
+      'docs/**/*.{ts,tsx,js,jsx,mjs}',
+      'src/**/*.{ts,tsx,js,jsx,mjs}',
+      '!**/node_modules',
+      '!**/doczrc.js',
+    ],
+  },
   port: '3003',
   menu: ['Class101 UI', 'Core', 'Components', 'Form Controls', 'Form Inputs', 'Overlays'],
   typescript: true,


### PR DESCRIPTION
PropsTable 이 렌더링 되도록 설정을 추가했습니다

<img width="1077" alt="스크린샷 2020-04-18 오후 2 57 10" src="https://user-images.githubusercontent.com/18302025/79629454-ecfea900-8184-11ea-968b-fe7640d9ec80.png">
