### PR TITLE
chore(ui): modal 사용시 overlay 이하 컴포넌트를 DOM에서 제거한다

### DIFF
--- a/src/overlays/OverlaidPortal/index.tsx
+++ b/src/overlays/OverlaidPortal/index.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import { useCallback, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
 
 import { isClient } from '../../utils';
@@ -60,7 +59,7 @@ export const OverlaidPortal = React.memo<OverlayProps>(props => {
         visible={opened}
         onClick={closeable ? onClose : undefined}
       >
-        {children}
+        {opened && children}
       </Overlay>
     </Portal>
   );


### PR DESCRIPTION
## 요약

reRender 등의 상황에서 modal 컴포넌트가 react dev tool 등으로 보았을때, 잔상이 남아있습니다. 
이렇게 잔상이 남는 부분이 성능상에 영향을 주는지, 혹은 의도된 부분인지 모르겠습니다만 해당 ui 컴포넌트를 사용하여 다른 컴포넌트의 re render를 파악하기 어려움이 있습니다. 

현재 컴포넌트는 OverlaidPortal에서 opened 상황에서 visibility로 컴포넌트를 가려줍니다. 이 상황에서 하위 컴포넌트를 DOM에서 제거함으로서 잔상을 제거하고자 합니다. 

의도된 상황이라면, PR을 거절 부탁드립니다. 

ps, 혹 이렇게 잔상이 남는게 성능상에 영향을 주는지 아시는 분 있으면 댓글 부탁 드립니다 ~

## 스크린샷

> setInterval로 state을 계속 업데이트하였을 때, 기존의 방식은 visibility 이하 컴포넌트들의 형태가 그대로 보여짐 

### 비포

![before](https://user-images.githubusercontent.com/8156543/80930903-7d79f200-8df1-11ea-98e6-8d5bf457ce86.gif)

### 애프터

![after](https://user-images.githubusercontent.com/8156543/80930906-823ea600-8df1-11ea-80ae-20a2e25dace4.gif)
