### PR TITLE
feat(ui): modal bottom sheet에 min height를 제거한다

### DIFF
--- a/src/overlays/ModalBottomSheet/ModalBottomSheet.tsx
+++ b/src/overlays/ModalBottomSheet/ModalBottomSheet.tsx
@@ -223,7 +223,6 @@ const Dialog = styled.div<{ visible: boolean }>`
   flex-direction: column;
   padding: 32px;
   width: 480px;
-  min-height: 360px;
   max-height: 800px;
   border-radius: 8px;
   background-color: ${white};
@@ -236,7 +235,6 @@ const Dialog = styled.div<{ visible: boolean }>`
     padding-bottom: calc(constant(safe-area-inset-bottom) + 24px);
     padding-bottom: calc(env(safe-area-inset-bottom) + 24px);
     width: 100%;
-    min-height: 240px;
     max-height: calc(100% - 48px);
     height: auto;
     border-bottom-left-radius: 0;


### PR DESCRIPTION
modal bottom sheet에서 고정되어 있던 minHeight를 제거하고, 
필요한 경우 modalStyle 로 넘기도록 수정합니다