### PR TITLE
chore: size-limit 적용할 파일을 glob 패턴을 사용해 찾지 않고 직접 지정한다

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -3,6 +3,12 @@
     "path": "dist/index.js"
   },
   {
-    "path": "dist/**/*.js"
+    "path": "dist/esm/index.js"
+  },
+  {
+    "path": "dist/esm/core/index.js"
+  },
+  {
+    "path": "dist/esm/Icon/index.js"
   }
 ]


### PR DESCRIPTION
## AS-IS
<img width="660" alt="스크린샷 2020-05-28 오후 1 04 20" src="https://user-images.githubusercontent.com/32455422/83097760-d896c000-a0e3-11ea-963b-012b0226993a.png">
현재 size-limit report가 못 생기게 나와서 좀 예쁘게 나오도록 변경했어요

