### PR TITLE
feat(web): 댓글 컴포넌트에서 "전체보기" 버튼을 숨길 수 있는 hideReadMore값을 추가한다.

### DIFF
--- a/src/components/Comment/Content/index.tsx
+++ b/src/components/Comment/Content/index.tsx
@@ -1,6 +1,5 @@
 import React, { PureComponent } from 'react';
 import styled, { css } from 'styled-components';
-
 import { gray500 } from '../../../core/Colors';
 import { body2 } from '../../../core/TextStyles';
 import { ButtonSize, TextButton } from '../../Button';
@@ -10,6 +9,7 @@ interface Props {
   maxLine: number;
   readMoreText: string;
   hideText: string;
+  hideReadMore?: boolean;
   onClick?: React.MouseEventHandler<HTMLDivElement>;
 }
 
@@ -31,14 +31,14 @@ export class CommentContent extends PureComponent<Props, State> {
   }
 
   public render() {
-    const { children, maxLine, onClick, readMoreText, hideText } = this.props;
+    const { children, maxLine, onClick, hideReadMore, readMoreText, hideText } = this.props;
     const { lineClampable, lineClamped } = this.state;
     return (
       <Container>
         <Content useLineClamp={lineClamped} maxLine={maxLine} ref={this.contentRef} onClick={onClick}>
           {children}
         </Content>
-        {lineClampable && (
+        {!hideReadMore && lineClampable && (
           <ClampToggleButton size={ButtonSize.SMALL} onClick={this.handleToggleClampButton}>
             {lineClamped ? readMoreText : hideText}
           </ClampToggleButton>

--- a/src/components/Comment/index.tsx
+++ b/src/components/Comment/index.tsx
@@ -1,6 +1,5 @@
 import React, { PureComponent, ReactElement, ReactNode } from 'react';
 import styled from 'styled-components';
-
 import { Caption1, Caption2 } from '../../core';
 import { gray500, orange600 } from '../../core/Colors';
 import { Avatar, AvatarProps, AvatarSize } from '../Avatar';
@@ -21,6 +20,7 @@ export interface CommentProps {
 
   readMoreText: string;
   hideText: string;
+  hideReadMore?: boolean;
 
   /** 대댓글이 표시되는 여부. */
   showChildren: boolean;
@@ -78,6 +78,7 @@ export class Comment extends PureComponent<CommentProps> {
       className,
       onClick,
       onContentClick,
+      hideReadMore = false,
       readMoreText,
       hideText,
     } = this.props;
@@ -104,6 +105,7 @@ export class Comment extends PureComponent<CommentProps> {
           <CommentContent
             readMoreText={readMoreText}
             hideText={hideText}
+            hideReadMore={hideReadMore}
             useLineClamp={!disableLineClamp}
             maxLine={maxLine}
             onClick={onContentClick}

--- a/src/components/Reply/Content/index.tsx
+++ b/src/components/Reply/Content/index.tsx
@@ -1,6 +1,5 @@
 import React, { FC, useCallback, useEffect, useState } from 'react';
 import styled, { css } from 'styled-components';
-
 import { gray500, gray800 } from '../../../core/Colors';
 import { body2 } from '../../../core/TextStyles';
 import { TextButton } from '../../Button';
@@ -10,11 +9,12 @@ interface Props {
   maxLine: number;
   readMoreText: string;
   hideText: string;
+  hideReadMore?: boolean;
   onClick?: React.MouseEventHandler<HTMLDivElement>;
 }
 
 export const ReplyContent: FC<Props> = React.memo(props => {
-  const { children, useLineClamp, maxLine, readMoreText, hideText, onClick } = props;
+  const { children, useLineClamp, maxLine, readMoreText, hideText, hideReadMore, onClick } = props;
 
   const [lineClamped, setLineClamped] = useState(true);
   const [lineClampable, setLineClampable] = useState(false);
@@ -54,7 +54,7 @@ export const ReplyContent: FC<Props> = React.memo(props => {
       <Content useLineClamp={lineClamped} maxLine={maxLine} ref={contentRef} onClick={onClick}>
         {children}
       </Content>
-      {lineClampable && (
+      {!hideReadMore && lineClampable && (
         <ClampToggleButton onClick={handleToggleClampButton}>{lineClamped ? readMoreText : hideText}</ClampToggleButton>
       )}
     </>

--- a/src/components/Reply/index.tsx
+++ b/src/components/Reply/index.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement, ReactNode, useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
-
 import { BreakPoints, Caption1, Caption2 } from '../../core';
 import { gray500, gray800, orange500 } from '../../core/Colors';
 import { Avatar, AvatarProps, AvatarSize } from '.././Avatar';
@@ -21,6 +20,7 @@ export interface ReplyProps {
 
   readMoreText: string;
   hideText: string;
+  hideReadMore: boolean;
 
   /** 대 댓글이 표시 되는 여부. */
   showChildren: boolean;
@@ -74,6 +74,7 @@ export const Reply = Object.assign(
       onContentClick,
       readMoreText = '전체보기',
       hideText = '숨기기',
+      hideReadMore = false,
     } = props;
 
     const avatarSize = useMemo(() => {
@@ -130,6 +131,7 @@ export const Reply = Object.assign(
           <ReplyContent
             readMoreText={readMoreText}
             hideText={hideText}
+            hideReadMore={hideReadMore}
             useLineClamp={!disableLineClamp}
             maxLine={maxLine}
             onClick={onContentClick}


### PR DESCRIPTION
<img width="392" alt="스크린샷 2020-06-23 오후 4 53 15" src="https://user-images.githubusercontent.com/18302025/85375975-10bde100-b572-11ea-871e-f8f1da8cb6c8.png">
<img width="328" alt="스크린샷 2020-06-23 오후 4 52 58" src="https://user-images.githubusercontent.com/18302025/85375984-15829500-b572-11ea-952a-43c2c99ff5bb.png">
