### PR TITLE
feat(web): tooltip 색상을 추가한다.

### DIFF
--- a/docs/overlays/Tooltip.mdx
+++ b/docs/overlays/Tooltip.mdx
@@ -44,6 +44,12 @@ The component that appears when the mouse hovers over it.
   </Tooltip>
 </Playground>
 
+<Playground>
+  <Tooltip content="This is tooltip" position={Position.RIGHT} color={TooltipColor.HOTPINK}>
+    <Button>Mouse hover</Button>
+  </Tooltip>
+</Playground>
+
 ## with State
 
 <Playground>

--- a/src/overlays/Tooltip/colors.ts
+++ b/src/overlays/Tooltip/colors.ts
@@ -1,16 +1,19 @@
-import { gray100, gray900, orange100, orange600 } from '../../core/Colors';
+import { gray100, gray900, orange100, orange600, red400 } from '../../core/Colors';
 
 export enum TooltipColor {
   ORANGE,
+  HOTPINK,
   DEFAULT,
 }
 
 export const tooltipBackgroundColors = {
   [TooltipColor.ORANGE]: orange600,
+  [TooltipColor.HOTPINK]: red400,
   [TooltipColor.DEFAULT]: gray900,
 };
 
 export const tooltipColors = {
   [TooltipColor.DEFAULT]: gray100,
+  [TooltipColor.HOTPINK]: gray100,
   [TooltipColor.ORANGE]: orange100,
 };


### PR DESCRIPTION
<img width="314" alt="스크린샷 2020-06-24 오후 5 03 03" src="https://user-images.githubusercontent.com/18302025/85519774-f69d0500-b63c-11ea-9391-08175f034f7e.png">

위 색상을 사용하기 위해서 추가했습니다.
(색상 이름 반(디자이너)이랑 고민하다가 HOTPINK로 정하긴 했는데.. 좋은 이름 있으면 춫천 받아용..)