### PR TITLE
feat: swiper navigation 스타일 오버라이딩이 적용되지 않는 문제를 수정한다

### DIFF
--- a/src/components/Swiper/ArrowNavigation/index.tsx
+++ b/src/components/Swiper/ArrowNavigation/index.tsx
@@ -1,47 +1,52 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { ChevronRight } from '../../../Icon';
+import { ChevronLeft, ChevronRight } from '../../../Icon';
 
 export const ArrowNavigation = () => {
   return (
     <>
-      <Button className="swiper-button-prev" direction="left">
-        <ChevronRight fillColor="white" />
+      <Button className="swiper-button-prev">
+        <ChevronLeft fillColor="white" />
       </Button>
-      <Button className="swiper-button-next" direction="right">
+      <Button className="swiper-button-next">
         <ChevronRight fillColor="white" />
       </Button>
     </>
   );
 };
 
-const Button = styled.button<{ direction: 'right' | 'left' }>`
-  background: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  position: absolute;
-  width: 48px;
-  margin-top: 0;
-  top: 0;
-  height: 100%;
-  border: 0;
-  background-image: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(0, 0, 0, 0.15));
-  ${props =>
-    props.direction === 'right'
-      ? `
-      right: 0;
-  `
-      : `
-      left: 0;
-      transform: rotate(-180deg);
-  `};
+const Button = styled.button`
+  &.swiper-button-prev,
+  &.swiper-button-next {
+    background: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    position: absolute;
+    width: 48px;
+    margin-top: 0;
+    top: 0;
+    height: 100%;
+    border: 0;
+  }
+
+  &.swiper-button-prev {
+    left: 0;
+    background-image: linear-gradient(90deg, rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0));
+  }
+
+  &.swiper-button-next {
+    right: 0;
+    background-image: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(0, 0, 0, 0.15));
+  }
+
   &.swiper-button-disabled {
     pointer-events: auto;
     cursor: not-allowed;
   }
+
   svg {
     flex: none;
   }

--- a/src/components/Swiper/DefaultNavigation/index.tsx
+++ b/src/components/Swiper/DefaultNavigation/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { elevation1 } from '../../../core/ElevationStyles';
-import { ChevronRight } from '../../../Icon';
+import { ChevronLeft, ChevronRight } from '../../../Icon';
 import { ButtonColor, IconButton } from '../../Button';
 
 const NAVIGATION_BUTTON_SIZE = 32;
@@ -11,33 +11,16 @@ export type NavigationDirection = 'right' | 'left';
 
 export const DefaultNavigation = () => {
   return (
-    <Container className="swiper-default-navigation">
-      <Button color={ButtonColor.WHITE} className="swiper-button-prev" direction="left" icon={<ChevronRight />} />
-      <Button color={ButtonColor.WHITE} className="swiper-button-next" direction="right" icon={<ChevronRight />} />
-    </Container>
+    <div className="swiper-default-navigation">
+      <Button color={ButtonColor.WHITE} className="swiper-button-prev" icon={<ChevronLeft />} />
+      <Button color={ButtonColor.WHITE} className="swiper-button-next" icon={<ChevronRight />} />
+    </div>
   );
 };
 
-const Button = styled(IconButton)<{ direction: 'right' | 'left' }>`
-  ${props =>
-    props.direction === 'right'
-      ? `
-      right: 0;
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
-    `
-      : `
-      right: ${NAVIGATION_BUTTON_SIZE}px;
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-      svg {
-        transform: rotate(180deg);
-      }
-`};
-`;
-
-const Container = styled.div`
-  > ${Button} {
+const Button = styled(IconButton)`
+  &.swiper-button-prev,
+  &.swiper-button-next {
     ${elevation1};
     width: 32px;
     height: 32px;
@@ -54,5 +37,17 @@ const Container = styled.div`
       opacity: 1;
       pointer-events: auto;
     }
+  }
+
+  &.swiper-button-prev {
+    right: ${NAVIGATION_BUTTON_SIZE}px;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  &.swiper-button-next {
+    right: 0;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
   }
 `;


### PR DESCRIPTION
class101-ui GlobalStyle의 스타일이 styled()로 생성된 컴포넌트의 스타일보다 문서 상에서 뒤에 생성되어서 컴포넌트의 스타일을 덮어 쓰는 문제가 있음

- [GlobalStyles using an attribute selector are loaded after regular styles](https://github.com/styled-components/styled-components/issues/2993)
> We currently don't guarantee an insertion order for global styles. I agree this should be fixed though.

라네유....

시간 여행 좀 했는데 styled-components 5.1.0 올린 시점부터 생긴 버그임다...ㅠㅠ
일단 우선순위 높이는 걸로 해결하겠음다