### PR TITLE
fix: Callout컴포넌트의 디스크립션이 없는 경우의 스타일을 수정한다

### DIFF
--- a/docs/components/Callout.mdx
+++ b/docs/components/Callout.mdx
@@ -22,6 +22,8 @@ import { imageSrc } from './interface';
   <Callout title="공지사항">
     설명문구가 들어가는 자리입니다. 설명문구가 들어가는 자리입니다. 설명문구가 들어가는 자리입니다
   </Callout>
+  <br />
+  <Callout title="공지사항" />
 </Playground>
 
 ## Status

--- a/src/components/Callout/component/index.tsx
+++ b/src/components/Callout/component/index.tsx
@@ -29,7 +29,7 @@ export class Callout extends PureComponent<Readonly<CalloutProps>> {
           <Icon>{icon && status === CalloutStatus.DEFAULT ? icon : iconByStatus[status]}</Icon>
           {title}
         </Title>
-        <Content>{children}</Content>
+        {children && <Content>{children}</Content>}
         {action && (
           <StyledButton size={ButtonSize.SMALL} color={ButtonColor.WHITE} {...action}>
             {action.content}
@@ -43,6 +43,9 @@ export class Callout extends PureComponent<Readonly<CalloutProps>> {
 const Container = styled.div<{
   status: CalloutStatusValue;
 }>`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   padding: 16px;
   border-radius: 3px;
   background-color: ${props => backgroundColorByStatus[props.status]};
@@ -50,7 +53,6 @@ const Container = styled.div<{
 
 const Title = styled.div`
   ${body2};
-  margin-bottom: 8px;
   font-weight: bold;
   display: inline-flex;
   align-items: center;
@@ -69,6 +71,7 @@ const Icon = styled.span`
 
 const Content = styled.div`
   ${caption1};
+  margin-top: 8px;
   > * + * {
     margin-top: 8px;
   }


### PR DESCRIPTION
<img width="1256" alt="스크린샷 2020-09-11 오후 6 56 00" src="https://user-images.githubusercontent.com/15900134/92907631-72e6fd80-f460-11ea-909f-633920e47552.png">
