### PR TITLE
fix: 네비게이션 메뉴 스타일을 수정한다

### DIFF
--- a/src/components/Navigation/NavigationSection/index.tsx
+++ b/src/components/Navigation/NavigationSection/index.tsx
@@ -40,7 +40,7 @@ export class NavigationSection extends React.PureComponent<InjectedProps, State>
         if (!item.subItems) {
           return;
         }
-        if (item.subItems.find(item => NavigationSection.isActiveLocation(prevProps.pathname, item))) {
+        if (item.subItems.find(subItem => NavigationSection.isActiveLocation(prevProps.pathname, subItem))) {
           openedSectionIndices.push(index);
         }
       });
@@ -66,7 +66,7 @@ export class NavigationSection extends React.PureComponent<InjectedProps, State>
             {action && React.cloneElement(action.icon, { size: 16 })}
           </SectionTitleContainer>
         ) : null}
-        {items.map(this.renderSectionItem)}
+        <SectionMenu>{items.map(this.renderSectionItem)}</SectionMenu>
       </Container>
     );
   }
@@ -124,16 +124,17 @@ export class NavigationSection extends React.PureComponent<InjectedProps, State>
     const { pathname } = this.props;
 
     return (
-      <SectionLink
-        key={index}
-        to={item.url}
-        external={item.external}
-        onClick={this.handleOnClickLink(item.url)}
-        active={NavigationSection.isActiveLocation(pathname, item)}
-      >
-        <SectionText>{item.label}</SectionText>
-        {this.renderAddonComponent(item.badge)}
-      </SectionLink>
+      <SubItem key={index}>
+        <SectionLink
+          to={item.url}
+          external={item.external}
+          onClick={this.handleOnClickLink(item.url)}
+          active={NavigationSection.isActiveLocation(pathname, item)}
+        >
+          <SectionText>{item.label}</SectionText>
+          {this.renderAddonComponent(item.badge)}
+        </SectionLink>
+      </SubItem>
     );
   };
 
@@ -161,8 +162,14 @@ export class NavigationSection extends React.PureComponent<InjectedProps, State>
 
 export default (NavigationSection as any) as React.ComponentClass<NavigationSectionProps>;
 
-const Container = styled.ul`
-  margin: 12px 0;
+const Container = styled.div`
+  margin-top: 12px;
+  border-radius: 4px;
+`;
+
+const SectionMenu = styled.ul`
+  list-style: none;
+  margin-bottom: 12px;
   border-radius: 4px;
 `;
 
@@ -205,22 +212,21 @@ const SectionItemStyle = css`
 
 const SectionLink = styled(LinkBlock)<{ active: boolean }>`
   ${SectionItemStyle};
-  ${props =>
-    props.active
-      ? css`
-    font-weight: bold;
-    color: ${gray900};
-    background-color: ${gray50};
+  ${({ active }) =>
+    active &&
+    css`
+      font-weight: bold;
+      color: ${gray900};
+      background-color: ${gray50};
 
-    path {
-      fill: ${gray900};
-    }
-  }`
-      : ''};
+      path {
+        fill: ${gray900};
+      }
+    `};
 `;
 
 const SectionItem = styled.div`
-  ${SectionItemStyle}
+  ${SectionItemStyle};
 `;
 
 const SectionText = styled.span`
@@ -232,18 +238,32 @@ const SectionText = styled.span`
 `;
 
 const SubItemContainer = styled.ul<{ isOpened: boolean }>`
+  list-style: none;
   margin: 0;
   padding: 0;
   padding-left: 28px;
-  transform: translateY(${props => (props.isOpened ? 0 : -40)}px);
-  height: ${props => (props.isOpened ? 'auto' : 0)};
-  transform-origin: top;
-  transition: transform 0.26s ease;
   overflow: hidden;
+  transform-origin: top;
+  transition: opacity 0.1s ease, transform 0.26s ease;
+
+  ${({ isOpened }) =>
+    isOpened
+      ? `
+    transform: translateY(0);
+    opacity: 1;
+    height: auto;
+  `
+      : `
+    transform: translateY(-40px);
+    opacity: 0;
+    height: 0;
+  `}
 `;
+
+const SubItem = styled.li``;
 
 const ChevronContainer = styled.span<{ isOpened: boolean }>`
   display: flex;
-  transform: rotate(${props => (props.isOpened ? 180 : 0)}deg);
+  transform: rotate(${({ isOpened }) => (isOpened ? 180 : 0)}deg);
   transition: transform 0.26s ease;
 `;


### PR DESCRIPTION
- 서브 메뉴가 노출되어 깨져보이는 걸 opacity 스타일 추가해서 수정했습니다.
<img width="834" alt="스크린샷 2020-11-06 오후 8 18 57" src="https://user-images.githubusercontent.com/15900134/98360762-c1360880-206d-11eb-802d-594cb5ac5b1b.png">
<img width="834" alt="스크린샷 2020-11-06 오후 8 19 44" src="https://user-images.githubusercontent.com/15900134/98360766-c2ffcc00-206d-11eb-8b63-a9b5abc55409.png">

- ul 하위로 li만 허용되기 때문에 구조를 수정했습니다.
> Permitted content | Zero or more `<li>`, `<script>` and `<template>` elements.
> -- | --
<img width="514" alt="스크린샷 2020-11-06 오후 8 20 58" src="https://user-images.githubusercontent.com/15900134/98360768-c430f900-206d-11eb-8a37-fd2ea9116adf.png">
<img width="514" alt="스크린샷 2020-11-06 오후 8 20 14" src="https://user-images.githubusercontent.com/15900134/98360767-c3986280-206d-11eb-9b75-383bcb9bceb3.png">




