### PR TITLE
feat: TagInput, Tag에서 disabled인 상태이면 CloseButton을 안 보이도록 한다.

### DIFF
--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -15,13 +15,15 @@ export interface TagProps {
 
 export class Tag extends PureComponent<TagProps> {
   public render() {
-    const { value, label, className, 'data-element-name': dataElementName } = this.props;
+    const { value, label, className, 'data-element-name': dataElementName, disabled } = this.props;
     return (
       <Container data-element-name={dataElementName} className={className}>
         <Text>{label || value}</Text>
-        <CloseButton onClick={this.handleRemoveButton}>
-          <Close size={16} />
-        </CloseButton>
+        {disabled !== false && (
+          <CloseButton onClick={this.handleRemoveButton}>
+            <Close size={16} />
+          </CloseButton>
+        )}
       </Container>
     );
   }

--- a/src/formInputs/TagInput/index.tsx
+++ b/src/formInputs/TagInput/index.tsx
@@ -84,7 +84,7 @@ export class TagInput extends PureComponent<TagInputProps, State> {
               {...inputProps}
             />
           </InnerContainer>
-          {value.length > 0 && (
+          {value.length > 0 && disabled !== false && (
             <IconButton
               icon={<Close />}
               size={ButtonSize.XSMALL}


### PR DESCRIPTION
disabled인데 전체 삭제 버튼이 눌리는 경우도 있고,

@bae-unidev 가 그냥 disabled일때 CloseButton이 안 보이는게 더 좋을 것 같다고 해서 관련하여 작업을 진행하였습니다