### PR TITLE
fix: ModalBottomSheet의 title과 subTitle간의 간격을 줄인다

### DIFF
--- a/src/overlays/ModalBottomSheet/ModalBottomSheet.tsx
+++ b/src/overlays/ModalBottomSheet/ModalBottomSheet.tsx
@@ -271,7 +271,7 @@ const DialogHead = styled.div`
   flex: none;
   display: flex;
   flex-direction: row;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
 `;
 
 const DialogTitle = styled(Headline3)`


### PR DESCRIPTION
프딩이들 사이에서 ModalBottomSheet에서 Title과 SubTitle 사이의 간격을 16px에서 8px로 줄이기로 했다해서 수정하였습니다

(기존)
![image](https://user-images.githubusercontent.com/38802280/102590530-0f9df300-4154-11eb-8950-86a7019432c8.png)

(수정)
![image](https://user-images.githubusercontent.com/38802280/102590518-0c0a6c00-4154-11eb-83f7-bc38fe5ca5b4.png)

미묘한 차이가 있습니당

기존 쓰고 있던 부분에서 변경해도 상관없다고 합니당