### PR TITLE
fix(ui): reply content가 중간으로 가는 문제를 수정한다

### DIFF
--- a/src/components/Reply/Content/index.tsx
+++ b/src/components/Reply/Content/index.tsx
@@ -61,7 +61,6 @@ export const ReplyContent: FC<Props> = React.memo(props => {
 const Content = styled.div<{ useLineClamp: boolean; maxLine: number }>`
   ${body2};
   display: -webkit-box;
-  -webkit-box-align: baseline;
   word-wrap: break-word;
   overflow: hidden;
   -webkit-box-orient: vertical;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32216112/105942336-61fef780-60a2-11eb-8321-e03b45f509f7.png)

문자가 중간으로 가는 문제를 수정하였습니다