### PR TITLE
feat: Reply컴포넌트에 HeaderAction props를 추가한다

### DIFF
--- a/docs/components/Reply.mdx
+++ b/docs/components/Reply.mdx
@@ -44,6 +44,11 @@ Reply 컴포넌트
     timeText="2시간 전"
     width="312px"
     nameDescription="크리에이터"
+    headerAction={[
+      { label: '수정하기', icon: <Icon.EditOutline /> },
+      { label: '알림 끄기', description: '해당 게시물의 메일과 푸시알림을 받지 않습니다.', icon: <Icon.BellOff /> },
+      { label: '삭제하기', textColor: Colors.red500 },
+    ]}
     leftAction={[
       <Reply.Action icon={<Icon.HeartOutline />} text="2" fillColor={Colors.gray500} />,
       <Reply.Action icon={<Icon.Reply />} text="답글 달기" fillColor={Colors.gray500} />,
@@ -170,6 +175,29 @@ width는 기본값으로 `100%`입니다.
         댓글 내용입니다.
       </div>
     }
+  />
+</Playground>
+
+## Header Action
+
+`headerAction`을 통해 헤더에 콤보박스를 추가할 수 있습니다. 자세한 내용은 [여기](/components/combo-box#comboboxprops) 를 확인해주세요.
+
+<Playground>
+  <Reply
+    avatar={<Avatar src={IMAGE_URL} />}
+    name="Class101"
+    content="댓글 1"
+    headerAction={[
+      { label: '수정하기', icon: <Icon.EditOutline /> },
+      { label: '알림 끄기', description: '해당 게시물의 메일과 푸시알림을 받지 않습니다.', icon: <Icon.BellOff /> },
+      { label: '삭제하기', textColor: Colors.red500 },
+    ]}
+    leftAction={[
+      <Reply.Action icon={<Icon.HeartOutline />} text="3" />,
+      <Reply.Action icon={<Icon.Trash />} onClick={() => alert('clicked!')} />,
+      <Reply.Action icon={<Icon.CheckboxOff />} hidden={true} />,
+      <Reply.Action icon={<Icon.CheckboxOn />} disabled />,
+    ]}
   />
 </Playground>
 

--- a/src/components/Reply/index.tsx
+++ b/src/components/Reply/index.tsx
@@ -1,6 +1,8 @@
+import { ComboBox, ComboBoxPosition, ComboBoxProps } from 'components/ComboBox';
+import { Icon } from 'index';
 import React, { ReactElement, ReactNode, useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
-import { BreakPoints, Caption1, Caption2 } from '../../core';
+import { BreakPoints, Caption1, Caption2, Colors } from '../../core';
 import { gray500, gray800 } from '../../core/Colors';
 import { Avatar, AvatarProps, AvatarSize } from '../Avatar';
 import { ButtonIconPosition } from '../Button/ButtonIcon';
@@ -37,6 +39,7 @@ export interface ReplyProps {
   timeText?: ReactNode;
   leftAction?: ReactElement<ReplyActionProps>[];
   rightAction?: ReactElement<ReplyActionProps>[];
+  headerAction?: ComboBoxProps[];
   content?: ReactNode;
   className?: string;
   'data-element-name'?: string;
@@ -65,6 +68,7 @@ export const Reply = Object.assign(
       content,
       leftAction,
       rightAction,
+      headerAction,
       children,
       disableLineClamp = false,
       showChildren = true,
@@ -123,6 +127,19 @@ export const Reply = Object.assign(
             </NameContainer>
             {size !== ReplySize.SMALL && <TimeText size={size}>{timeText}</TimeText>}
           </TitleContainer>
+          {headerAction && (
+            <HeaderActionContainer>
+              <ComboBox
+                items={headerAction}
+                opener={
+                  <HeaderActionIconWrapper>
+                    <Icon.MoreHorizontal fillColor={Colors.gray600} />
+                  </HeaderActionIconWrapper>
+                }
+                position={ComboBoxPosition.LEFT}
+              />
+            </HeaderActionContainer>
+          )}
         </DescriptionContainer>
         <ContentWrapper marginLeft={contentMargin} size={size}>
           <ReplyContent
@@ -198,6 +215,12 @@ const TitleContainer = styled.div`
   flex: 1;
   flex-direction: column;
   margin-left: 12px;
+`;
+
+const HeaderActionContainer = styled.div``;
+
+const HeaderActionIconWrapper = styled.div`
+  cursor: pointer;
 `;
 
 const NameDescriptionContainer = styled.div`


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38802280/116365109-e5fe8200-a83f-11eb-9ebb-2d3ab30c2145.png)

Reply컴포넌트에 headerAction props를 추가하였습니다. headerAction에는 [ComboBoxItemProps](https://ui.class101.dev/components/combo-box#comboboxprops) 로 이루어진 배열값을 받으며, 해당 배열값을 통해 헤더에 [ComboBox](https://ui.class101.dev/components/combo-box)를 그려줍니다,

leftAction, rightAction과 다르게 해당 prop의 경우 좀 더 strict하게 관리하려고 합니다.
(leftAction, rightAction은 클릭 아이콘이나 등 도 같이 받고있지만, 해당 prop의 경우 짜여진 틀에 데이터만 넘겨서 관리하고자 합니다)

이렇게 하는게 흐름상 문제는 없을까요?? 뭔가 다른 props와 달라서 이질감이 생길수도 있을거같아서,,, 그리고 headerAction이란 prop name도 이상한거같은데 혹시 대체할만한게 있을까요?? 코멘트로 남겨주시면 감사하겠습니다:)