### PR TITLE
fix: Reply 컴포넌트의 nameDescription 스타일 오류를 수정한다

### DIFF
--- a/src/components/ComboBox/index.tsx
+++ b/src/components/ComboBox/index.tsx
@@ -101,7 +101,7 @@ export const ComboBoxItem = ({ icon, label, description, to, textColor, onClick 
 
   const innerElements = (
     <InnerElementWrapper>
-      {icon}
+      <IconWrapper>{icon}</IconWrapper>
       <TextWrapper>
         <Label>{label}</Label>
         {description && <Description>{description}</Description>}
@@ -145,6 +145,14 @@ const ActionItemList = styled.div<{ visible?: boolean; position?: ComboBoxPositi
 const InnerElementWrapper = styled.div`
   display: flex;
   flex-direction: row;
+`;
+
+const IconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
 `;
 
 const TextWrapper = styled.div`

--- a/src/components/Reply/index.tsx
+++ b/src/components/Reply/index.tsx
@@ -3,7 +3,7 @@ import { Icon } from 'index';
 import React, { ReactElement, ReactNode, useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { BreakPoints, Caption1, Caption2, Colors } from '../../core';
-import { gray500, gray800 } from '../../core/Colors';
+import { gray500, gray800, orange500 } from '../../core/Colors';
 import { Avatar, AvatarProps, AvatarSize } from '../Avatar';
 import { ButtonIconPosition } from '../Button/ButtonIcon';
 import { ReplyAction, ReplyActionProps } from './Action';
@@ -33,6 +33,7 @@ export interface ReplyProps {
   size: ReplySize;
   width: string;
   nameDescription?: ReactNode;
+  nameDescriptionColor?: string;
   extraBottom?: ReactNode;
   avatar?: ReactElement<AvatarProps>;
   footer?: ReactNode;
@@ -61,6 +62,7 @@ export const Reply = Object.assign(
       avatar,
       name,
       nameDescription,
+      nameDescriptionColor = orange500,
       extraBottom,
       timeText,
       width = '100%',
@@ -122,7 +124,15 @@ export const Reply = Object.assign(
               <Caption1 fontWeight="600" color={gray800}>
                 {name}
               </Caption1>
-              {nameDescription && <NameDescriptionContainer>{nameDescription}</NameDescriptionContainer>}
+              {nameDescription && (
+                <NameDescriptionContainer size={size}>
+                  {typeof nameDescription === 'string' ? (
+                    <NameDescription color={nameDescriptionColor}>{nameDescription}</NameDescription>
+                  ) : (
+                    nameDescription
+                  )}
+                </NameDescriptionContainer>
+              )}
               {size === ReplySize.SMALL && <TimeText size={size}>{timeText}</TimeText>}
             </NameContainer>
             {size !== ReplySize.SMALL && <TimeText size={size}>{timeText}</TimeText>}
@@ -223,9 +233,11 @@ const HeaderActionIconWrapper = styled.div`
   cursor: pointer;
 `;
 
-const NameDescriptionContainer = styled.div`
+const NameDescriptionContainer = styled.div<{ size: ReplySize }>`
   margin-left: 4px;
 `;
+
+const NameDescription = styled(Caption2)``;
 
 const TimeText = styled(Caption2)<{ size: ReplySize }>`
   margin-top: ${props => (props.size === ReplySize.SMALL ? '0' : '2px')};


### PR DESCRIPTION
기존에 string으로 받던 nameDescription 필드를 ReactNode로 받으면서, string값이 들어올 경우 스타일이 깨지는 케이스가 생겼습니다. (기존 string은 스타일로 래핑되어있었는데 Node로 변경되면서 사라짐)

관련 PR: https://github.com/pedaling/class101-ui/pull/309/files

그래서 title이 string일 때는 기본적인 스타일을 먹여주고 아닐 경우엔 ReactNode그대로 보여주도록 수정하였습니다.

string 값을 넘겨줄 때

```typescript
<Reply
    avatar={
      <Avatar
        src={IMAGE_URL}
        icon={
          <Badge backgroundColor={Colors.orange600} pill>
            <Icon.Crown fillColor={Colors.white} />
          </Badge>
        }
      />
    }
    name="서지"
    timeText="2시간 전"
    width="312px"
    nameDescription="크리에이터"
...
/>
```

![image](https://user-images.githubusercontent.com/38802280/116496836-e6028e80-a8e0-11eb-85be-d2674e22572b.png)

ReactNode를 넘겨줄 때 (원하는 형식으로)
```typescript
() => (
  <Reply
    avatar={
      <Avatar
        src={IMAGE_URL}
        icon={
          <Badge backgroundColor={Colors.orange600} pill>
            <Icon.Crown fillColor={Colors.white} />
          </Badge>
        }
      />
    }
    name="서지"
    timeText="2시간 전"
    width="312px"
    nameDescription={<div style={{color: '#eee', fontSize: 18}}>크리에이터</div>}
...
/>
```

![image](https://user-images.githubusercontent.com/38802280/116497546-a177f280-a8e2-11eb-878f-6fea6a8a1094.png)


추가적으로 ComboBox 기본 아이콘 사이즈를잡아놨어여