### PR TITLE
fix: ComboBox 컴포넌트에 아이콘이 있을때만 공간을 차지하도록 수정한다

### DIFF
--- a/src/components/ComboBox/index.tsx
+++ b/src/components/ComboBox/index.tsx
@@ -101,7 +101,7 @@ export const ComboBoxItem = ({ icon, label, description, to, textColor, onClick 
 
   const innerElements = (
     <InnerElementWrapper>
-      <IconWrapper>{icon}</IconWrapper>
+      {icon && <IconWrapper>{icon}</IconWrapper>}
       <TextWrapper>
         <Label>{label}</Label>
         {description && <Description>{description}</Description>}


### PR DESCRIPTION
아이콘이 있을때만 영역을 차지하도록 수정했어여

Before

![image](https://user-images.githubusercontent.com/38802280/116503613-7c3eb080-a8f1-11eb-8a6e-c0d8b82e2af7.png)


After

![image](https://user-images.githubusercontent.com/38802280/116503559-65985980-a8f1-11eb-819e-0d13f238cd23.png)
