### PR TITLE
style: 기존 아이콘 사용 방식에 `@deprecated` 처리를 한다

### DIFF
--- a/src/Icon/index.ts
+++ b/src/Icon/index.ts
@@ -1,10 +1,22 @@
-import * as Icon from './export-legacy.generated';
+import * as LegacyIcon from './export-legacy.generated';
 
 export * from './export.generated';
 export * from './types';
 
 /**
- * MEMO(Naki, @nbsp1221): 기존 코드와의 호환성을 위해 레거시 버전을 고려함
- * @deprecated 트리 쉐이킹 문제로 사용하시면 안됩니다.
+ * 트리 쉐이킹(Tree Shaking) 문제로 아이콘 사용 방법을 변경합니다.
+ * 기존 방식은 호환성을 위해 남겨두었습니다.
+ *
+ * @author Naki(nbsp1221)
+ * @deprecated 이 방식은 더 이상 사용되지 않습니다. 새로운 방식의 아이콘을 사용해 주세요.
+ * @example
+ *   // Before
+ *   import { Icon } from '@class101/ui';
+ *   const IconComponent = () => <Icon.Add />;
+ *
+ *   // After
+ *   import { AddIcon } from '@class101/ui';
+ *   const IconComponent = () => <AddIcon />;
+ *
  */
-export { Icon };
+export const Icon = LegacyIcon;

--- a/src/Icon/index.ts
+++ b/src/Icon/index.ts
@@ -17,6 +17,5 @@ export * from './types';
  *   // After
  *   import { AddIcon } from '@class101/ui';
  *   const IconComponent = () => <AddIcon />;
- *
  */
 export const Icon = LegacyIcon;


### PR DESCRIPTION
https://github.com/pedaling/class101-ui/pull/340

트리 쉐이킹 문제로 아이콘 사용 방식을 변경함에 따라 기존 사용 방식에 설명과 `@deprecated`를 추가했습니다.