### PR TITLE
refactor: Swiper, Carousel 컴포넌트를 함수형으로 리팩토링한다

### DIFF
--- a/docs/components/Carousel.mdx
+++ b/docs/components/Carousel.mdx
@@ -5,7 +5,7 @@ route: /components/carousel
 ---
 
 import { Playground, Props } from 'docz';
-import { Carousel, Slide, CarouselNavigationPosition, CarouselPaginationTheme, Section, Colors } from '@class101/ui';
+import { Carousel, Slide, CarouselNavigationPosition, CarouselPaginationTheme, Section, Colors, ViewAllButton } from '@class101/ui';
 import { imageSrc } from './interface';
 import { PlayGroundBanner, PlayGroundSectionCarouselContent, SwiperCard, PreloadImage } from '../docsComponents';
 
@@ -245,7 +245,7 @@ enum CarouselPaginationTheme {
           <PlayGroundBanner backgroundColor={Colors[`blue${order * 100}`]}>배너{order}</PlayGroundBanner>
         </Slide>
       ))}
-      <Carousel.ViewAllButton />
+      <ViewAllButton />
     </Carousel>
   </Section>
 </Playground>

--- a/src/components/Swiper/ArrowNavigation/index.tsx
+++ b/src/components/Swiper/ArrowNavigation/index.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
-
 import { ChevronLeftIcon, ChevronRightIcon } from '../../../Icon';
 
-export const ArrowNavigation = () => {
+export const ArrowNavigation = React.memo(() => {
   return (
     <>
       <Button className="swiper-button-prev">
@@ -14,7 +13,7 @@ export const ArrowNavigation = () => {
       </Button>
     </>
   );
-};
+});
 
 const Button = styled.button`
   &.swiper-button-prev,

--- a/src/components/Swiper/DefaultNavigation/index.tsx
+++ b/src/components/Swiper/DefaultNavigation/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-
 import { elevation1 } from '../../../core/ElevationStyles';
 import { ChevronLeftIcon, ChevronRightIcon } from '../../../Icon';
 import { ButtonColor, IconButton } from '../../Button';
@@ -9,14 +8,14 @@ const NAVIGATION_BUTTON_SIZE = 32;
 
 export type NavigationDirection = 'right' | 'left';
 
-export const DefaultNavigation = () => {
+export const DefaultNavigation = React.memo(() => {
   return (
     <div className="swiper-default-navigation">
       <Button color={ButtonColor.WHITE} className="swiper-button-prev" icon={<ChevronLeftIcon />} />
       <Button color={ButtonColor.WHITE} className="swiper-button-next" icon={<ChevronRightIcon />} />
     </div>
   );
-};
+});
 
 const Button = styled(IconButton)`
   &.swiper-button-prev,

--- a/src/components/Swiper/Slide/index.tsx
+++ b/src/components/Swiper/Slide/index.tsx
@@ -6,6 +6,6 @@ export interface SlideProps {
   children?: React.ReactNode;
 }
 
-export const Slide = (props: SlideProps) => {
+export const Slide = React.memo<SlideProps>(props => {
   return <div className={classNames('swiper-slide', props.className)}>{props.children}</div>;
-};
+});

--- a/src/components/Swiper/index.tsx
+++ b/src/components/Swiper/index.tsx
@@ -1,6 +1,7 @@
 // eslint-disable-next-line prettier/prettier
 import classNames from 'classnames';
 import React, { FC, MutableRefObject, ReactNode, useEffect, useRef, useState } from 'react';
+import { SwiperOptions } from 'swiper';
 import {
   Autoplay,
   EffectFade,
@@ -11,7 +12,6 @@ import {
   Swiper as OriginalSwiper,
   Virtual,
 } from 'swiper/dist/js/swiper.esm.js';
-import type { SwiperOptions } from 'swiper';
 import { createUniqIDGenerator } from '../../utils/createUniqIDGenerator';
 import { DefaultNavigation } from './DefaultNavigation';
 
@@ -32,15 +32,34 @@ const generateId = createUniqIDGenerator('swiper-');
 
 export const Swiper: FC<SwiperProps> = ({
   getSwiperInstance,
-  className,
+  className = '',
   children,
-  navigationChildren,
-  paginationChildren,
+  navigationChildren = <DefaultNavigation />,
+  paginationChildren = <div className="swiper-pagination" />,
   'data-element-name': dataElementName,
+  pagination = {
+    el: '.swiper-pagination',
+    type: 'bullets',
+    clickable: true,
+  },
+  navigation = {
+    nextEl: '.swiper-button-next',
+    prevEl: '.swiper-button-prev',
+  },
+  speed = 400,
+  threshold = 10,
+  observer = true,
   ...swiperOptions
 }) => {
   const swiperRef: MutableRefObject<OriginalSwiper | null> = useRef(null);
-  const swiperOptionsRef: MutableRefObject<SwiperOptions> = useRef(swiperOptions);
+  const swiperOptionsRef: MutableRefObject<SwiperOptions> = useRef({
+    ...swiperOptions,
+    pagination,
+    navigation,
+    speed,
+    threshold,
+    observer,
+  });
   const [containerId, setContainerId] = useState<string | undefined>(undefined);
 
   useEffect(() => {
@@ -72,22 +91,3 @@ export const Swiper: FC<SwiperProps> = ({
     </div>
   );
 };
-
-Swiper.defaultProps = {
-  paginationChildren: <div className="swiper-pagination" />,
-  navigationChildren: <DefaultNavigation />,
-  freeMode: false,
-  observer: true,
-  pagination: {
-    el: '.swiper-pagination',
-    type: 'bullets',
-    clickable: true,
-  },
-  navigation: {
-    nextEl: '.swiper-button-next',
-    prevEl: '.swiper-button-prev',
-  },
-  threshold: 10,
-  speed: 400,
-  className: '',
-} as Partial<SwiperProps>;

--- a/src/components/Swiper/index.tsx
+++ b/src/components/Swiper/index.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line prettier/prettier
 import classNames from 'classnames';
 import React, { FC, MutableRefObject, ReactNode, useEffect, useRef, useState } from 'react';
-import { SwiperOptions } from 'swiper';
+import type { SwiperOptions } from 'swiper';
 import {
   Autoplay,
   EffectFade,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,6 +7,7 @@ export * from './ComboBox';
 export * from './Callout';
 export * from './Card';
 export * from './Carousel';
+export { default as ViewAllButton } from './Carousel/ViewAllButton';
 export * from './Comment';
 export * from './FilterList';
 export * from './Navigation';


### PR DESCRIPTION
Swiper 버전을 그냥 올렸더니 동작이 안되는 부분이 너무 많아서 하나씩 해보려고 일단 함수형으로 리팩토링 먼저 했습니다.

함수형으로 리팩토링 하는 과정에서 `Carousel.ViewAllButton` 컴포넌트가 `ViewAllButton`로 분리되었습니다.