### PR TITLE
fix: `Carousel` 컴포넌트에 `children` 타입을 추가한다

### DIFF
--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -23,7 +23,7 @@ type SwiperPropsForCaorusel = Partial<
   >
 >;
 
-export interface CarouselProps {
+export type CarouselProps = React.PropsWithChildren<{
   swiperProps?: SwiperPropsForCaorusel;
   className?: string;
   lgSlidesPerView: SlidesPerView;
@@ -43,7 +43,7 @@ export interface CarouselProps {
   pagination?: boolean;
   navigation?: boolean;
   'data-element-name'?: string;
-}
+}>;
 
 export enum CarouselNavigationPosition {
   TopRightOut = 'TopRightOut',


### PR DESCRIPTION
타입 오류 문제를 해결합니다