### PR TITLE
fix: `Carousel` 컴포넌트 프롭을 Optional 하게 설정한다

### DIFF
--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -26,12 +26,12 @@ type SwiperPropsForCaorusel = Partial<
 export type CarouselProps = React.PropsWithChildren<{
   swiperProps?: SwiperPropsForCaorusel;
   className?: string;
-  lgSlidesPerView: SlidesPerView;
-  smSlidesPerView: SlidesPerView;
+  lgSlidesPerView?: SlidesPerView;
+  smSlidesPerView?: SlidesPerView;
   lgSpaceBetween?: boolean;
   smSpaceBetween?: boolean;
-  lgSlidesSideOffset: number;
-  smSlidesSideOffset: number;
+  lgSlidesSideOffset?: number;
+  smSlidesSideOffset?: number;
   activeIndex?: number;
   onChangeSlide?: (index: number) => void;
   onTransitionEnd?: () => void;


### PR DESCRIPTION
클래스 컴포넌트일때는 이게 왜 동작했는지 신기할 따름..
함수형으로 리팩토링하는게 쉽지가 않군요 😭 