### PR TITLE
chore: 배포를 쉽게 할 수 있는 `yarn npm-publish` 명령어를 추가한다

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "test": "cross-env CI=1 react-scripts-ts test --env=jsdom",
     "test:watch": "react-scripts-ts test --env=jsdom",
+    "npm-publish": "yarn prebuild && yarn build && npm publish",
     "build": "docz build && dist-size ./dist",
     "prebuild": "tsc -p . && rollup -c",
     "analyze": "cross-env RUNNING_ENV=analyze yarn prebuild",


### PR DESCRIPTION
배포하기 전에 `yarn prebuild`를 해야하는데 이를 하지 못해서 삽질하던 문제가 있었습니다. (가이드 문서에는 `yarn build`를 하라고 나와있음)
이를 해결하기 위해 배포 커맨드를 만들었습니다.