### PR TITLE
fix: `RadioButtonGroup` 버그를 해결한다

### DIFF
--- a/src/formControls/RadioButtonGroup/index.tsx
+++ b/src/formControls/RadioButtonGroup/index.tsx
@@ -1,5 +1,5 @@
 import { isEqual, pick } from 'lodash';
-import React, { isValidElement, PureComponent, Component } from 'react';
+import React, { isValidElement, PureComponent } from 'react';
 import styled from 'styled-components';
 
 import { RadioButton, RadioButtonContainerProps, RadioButtonProps } from './RadioButton';

--- a/src/formControls/RadioButtonGroup/index.tsx
+++ b/src/formControls/RadioButtonGroup/index.tsx
@@ -1,5 +1,5 @@
 import { isEqual, pick } from 'lodash';
-import React, { isValidElement, PureComponent } from 'react';
+import React, { isValidElement, PureComponent, Component } from 'react';
 import styled from 'styled-components';
 
 import { RadioButton, RadioButtonContainerProps, RadioButtonProps } from './RadioButton';
@@ -27,11 +27,13 @@ export class RadioButtonGroup extends PureComponent<RadioButtonGroupProps, State
         }
         return false;
       });
+
       if (state.checkedIndex !== index) {
         return { checkedIndex: index };
       }
     }
-    return { checkedIndex: 0 };
+
+    return null;
   }
 
   public state: State = { checkedIndex: 0 };
@@ -57,6 +59,7 @@ export class RadioButtonGroup extends PureComponent<RadioButtonGroupProps, State
     const child = this.arrayOfChildren[index];
 
     this.setState({ checkedIndex: index });
+
     if (onChange) {
       onChange(child ? child.props.value : '');
     }


### PR DESCRIPTION
`RadioButtonGroup`을 사용하고 있는 곳에서 다른 라디오 버튼이 선택되지 않는 버그를 해결했습니다.

이거 하면서 보니까 https://ui.class101.dev/ 에 있는 예제들이 잘못된 경우가 은근 있더라고요. (즉, 이게 정상 작동하는지 확신을 가질 수 없음)

나중에 모노레포로 합쳐지면서 스토리북으로 예제들 다시 작성해야 할 것 같습니다.

## 지금 당장의 문제점

이 부분만 마스터에 머지 후 `class101-ui` 버전을 바꿔서 배포해야 하는데 지금 마스터에는 네롤리가 작업했던 히스토리가 굉장히 많아서 쉽지 않을 것 같습니다. 좋은 방법 없을까요?